### PR TITLE
docs: add prominent development warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # JeansPy
 
+## ⚠️ Development Status
+
+> [!WARNING]
+> **JeansPy is under active development and may not work correctly.** APIs, numerical behavior, and supported workflows may change without notice. Some parts of the code may be incomplete or insufficiently validated, so results should be independently checked before they are used for scientific conclusions.
+
 JeansPy is a Python toolkit for Jeans analysis of dwarf spheroidal galaxies. It combines classical dynamical modeling utilities with optional JAX and NumPyro inference workflows for research use.
 
 ## Highlights


### PR DESCRIPTION
## Summary

Adds a prominent warning at the top of the README that JeansPy is still under active development and may not work correctly.

The warning also notes that APIs and numerical behavior may change and that scientific results should be independently validated.

## Why

The repository is not yet intended to present itself as a stable, validated release. This makes that status immediately visible to users before installation or use.