### PR TITLE
ci: run tests on pushes and pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  base:
+    name: Base install smoke test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install base package
+        run: uv sync
+
+      - name: Run base import test
+        run: uv run --with pytest pytest tests/test_import.py -q
+
+  numpyro-cpu:
+    name: NumPyro CPU test suite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install CPU development environment
+        run: uv sync --extra numpyro_cpu --extra dev
+
+      - name: Run tests
+        run: uv run pytest -q


### PR DESCRIPTION
## Summary

Adds a regular GitHub Actions test workflow in addition to the existing tag-triggered release workflow.

- smoke-tests the base installation
- installs the NumPyro CPU development environment
- runs the normal pytest suite (slow `mcmc` tests remain opt-in via the existing pytest configuration)

## Why

The current release workflow validates builds only when a version tag is pushed. Running tests on ordinary pushes and pull requests should catch regressions before release preparation.