### PR TITLE
chore: ignore generated notebook and test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,11 @@ dmypy.json
 
 # demo outputs
 notebooks/_demo_outputs
+notebooks/*.nc
+notebooks/*.zarr/
+
+# test outputs
+tests/artifacts/
 
 # benchmark outputs
 benchmarks/jeans_comparison/artifacts/


### PR DESCRIPTION
## Summary

Adds ignore rules for generated notebook and test outputs that should not be committed:

- `notebooks/*.nc`
- `notebooks/*.zarr/`
- `tests/artifacts/`

## Why

Generated inference outputs had previously been committed and were removed during repository cleanup. These rules reduce the chance of reintroducing large or machine-specific artifacts.