### PR TITLE
ci: pin actions used by the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false
 
       - name: Install base package
         run: uv sync
@@ -34,10 +38,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false
 
       - name: Install CPU development environment
         run: uv sync --extra numpyro_cpu --extra dev


### PR DESCRIPTION
## Summary

Pins the Actions used by the newly added test workflow to the same immutable commit SHAs already used by the release workflow, and disables unnecessary checkout credentials/cache state.

## Why

The first run of the test workflow completed with `startup_failure` before any job started. The release workflow already uses SHA-pinned Actions, so this aligns the test workflow with that existing repository convention and avoids action-policy/version ambiguity.