### PR TITLE
Test sampler wildcard import directly

### DIFF
--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -22,6 +22,13 @@ def test_sampler_wildcard_import_no_legacy_names():
         assert name not in namespace, f"{name} should not be imported from jeanspy.sampler"
 
 
+def test_sampler_legacy_names_not_accessible():
+    from jeanspy import sampler
+
+    for name in ("DSphSimulator", "Network", "Worker", "_LEGACY_SWYFT_EXPORTS"):
+        assert not hasattr(sampler, name), f"{name} should not be accessible on sampler module"
+
+
 def test_sampler_class_importable():
     from jeanspy.sampler import Sampler
     assert Sampler is not None

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -14,10 +14,12 @@ def test_sampler_all_contains_only_sampler():
 
 
 def test_sampler_wildcard_import_no_legacy_names():
-    from jeanspy import sampler
+    namespace = {}
+    exec("from jeanspy.sampler import *", namespace)
+
+    assert "Sampler" in namespace
     for name in ("DSphSimulator", "Network", "Worker", "_LEGACY_SWYFT_EXPORTS"):
-        assert name not in sampler.__all__, f"{name} should not be in sampler.__all__"
-        assert not hasattr(sampler, name), f"{name} should not be accessible on sampler module"
+        assert name not in namespace, f"{name} should not be imported from jeanspy.sampler"
 
 
 def test_sampler_class_importable():


### PR DESCRIPTION
Follow-up to #20 and Copilot review 5037920282.

This updates the sampler import regression test so it actually executes `from jeanspy.sampler import *` in a fresh namespace via `exec`. The test verifies that `Sampler` is imported and that the removed legacy Swyft names are not.

The existing strict `sampler.__all__ == ["Sampler"]` assertion is intentionally retained because it serves as an explicit public-API regression check.