### PR TITLE
Clean up NumPyro DM mass-selection API

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,11 @@ default model-aware choice: it uses the analytic NFW mass and the fixed-grid
 numeric mass for Zhao. The Zhao analytic mass uses
 `jax.scipy.special.betainc`; JAX does not provide autodiff through its shape
 parameters, so gradients through Zhao `a`, `b`, or `g` can fail on that path.
-The default `DSphModel.sigmalos2(..., use_analytic_dm=None)` follows the same
-choice and is the NUTS-safe path. Use `use_analytic_dm=False` (or
-`method="numeric"`) to force numeric mass, and request `method="analytic"` or
-`use_analytic_dm=True` explicitly only when the closed form is desired without
-those Zhao shape-parameter gradients.
+The default `DSphModel.sigmalos2(..., dm_mass_method="auto")` follows the same
+choice and is the NUTS-safe path. Use `dm_mass_method="numeric"` to force
+numeric mass, and request `method="analytic"` or
+`dm_mass_method="analytic"` explicitly only when the closed form is desired
+without those Zhao shape-parameter gradients.
 
 ## Example Notebooks
 

--- a/src/jeanspy/model_numpyro.py
+++ b/src/jeanspy/model_numpyro.py
@@ -640,7 +640,7 @@ class PlummerModel(StellarModel):
 
 class DMModel(Model):
     required_models: Mapping[str, type[Model]] = {}
-    _default_enclosed_mass_method = "numeric"
+    analytic_enclosed_mass_autodiff_safe = False
 
     def resolve_params(self, params: Mapping[str, Any]) -> Mapping[str, Any]:
         return params
@@ -705,9 +705,18 @@ class DMModel(Model):
         request a closed form explicitly, or ``method="numeric"`` for the
         autodiff-friendly numerical integral.
         """
-        resolved_method = (
-            self._default_enclosed_mass_method if method == "auto" else method
-        )
+        method_key = str(method).strip().lower()
+        if method_key == "auto":
+            resolved_method = (
+                "analytic"
+                if (
+                    bool(self.analytic_enclosed_mass_autodiff_safe)
+                    and self.has_analytic_enclosed_mass
+                )
+                else "numeric"
+            )
+        else:
+            resolved_method = method_key
         has_analytic = self.has_analytic_enclosed_mass
         if resolved_method == "analytic":
             if has_analytic:
@@ -732,7 +741,7 @@ class DMModel(Model):
 
 class NFWModel(DMModel):
     required_param_names = ("rs_pc", "rhos_Msunpc3", "r_t_pc")
-    _default_enclosed_mass_method = "analytic"
+    analytic_enclosed_mass_autodiff_safe = True
 
     def resolve_params(self, params: Mapping[str, Any]) -> dict[str, jnp.ndarray]:
         rs = jnp.asarray(params["rs_pc"])
@@ -772,6 +781,7 @@ class NFWModel(DMModel):
 
 class ZhaoModel(DMModel):
     required_param_names = ("rs_pc", "rhos_Msunpc3", "a", "b", "g", "r_t_pc")
+    analytic_enclosed_mass_autodiff_safe = False
 
     def mass_density_3d(
         self, r_pc: jnp.ndarray, *, params: Mapping[str, Any]
@@ -1122,13 +1132,21 @@ class DSphModel(Model):
 
     @staticmethod
     def _resolve_dm_mass_method(
-        dm: DMModel, use_analytic_dm: Optional[bool]
+        dm: DMModel, dm_mass_method: str
     ) -> str:
-        if use_analytic_dm is None:
-            return dm._default_enclosed_mass_method
-        if use_analytic_dm and dm.has_analytic_enclosed_mass:
-            return "analytic"
-        return "numeric"
+        method_key = str(dm_mass_method).strip().lower()
+        if method_key not in {"auto", "analytic", "numeric"}:
+            raise ValueError(
+                "dm_mass_method must be 'auto', 'analytic', or 'numeric', "
+                f"got {dm_mass_method!r}"
+            )
+        if method_key == "auto":
+            return (
+                "analytic"
+                if (dm.analytic_enclosed_mass_autodiff_safe and dm.has_analytic_enclosed_mass)
+                else "numeric"
+            )
+        return method_key
 
     def sigmalos2_kernel(
         self,
@@ -1140,7 +1158,7 @@ class DSphModel(Model):
         n_kernel: Optional[int] = None,
         constant_kernel_backend: str = DEFAULT_CONSTANT_KERNEL_BACKEND,
         u_min_eps: float = 1e-6,
-        use_analytic_dm: Optional[bool] = None,
+        dm_mass_method: str = "auto",
     ) -> jnp.ndarray:
         r"""Original kernel-based sigma_los^2(R) implementation.
 
@@ -1168,7 +1186,7 @@ class DSphModel(Model):
         stellar: StellarModel = self.submodels["StellarModel"]  # type: ignore[assignment]
         dm: DMModel = self.submodels["DMModel"]  # type: ignore[assignment]
         ani: AnisotropyModel = self.submodels["AnisotropyModel"]  # type: ignore[assignment]
-        dm_mass_method = self._resolve_dm_mass_method(dm, use_analytic_dm)
+        dm_mass_method = self._resolve_dm_mass_method(dm, dm_mass_method)
 
         re_pc = params["re_pc"]
         nu3 = stellar.density_3d(r, re_pc=re_pc)
@@ -1216,7 +1234,7 @@ class DSphModel(Model):
         n_r: Optional[int] = None,
         u_max: Optional[float] = None,
         r_min_factor: float = 0.5,
-        use_analytic_dm: Optional[bool] = None,
+        dm_mass_method: str = "auto",
     ) -> jnp.ndarray:
         r"""Compute sigma_los^2(R) via a 1D Jeans solve and two Abel transforms."""
         R = jnp.atleast_1d(jnp.asarray(R_pc))
@@ -1228,7 +1246,7 @@ class DSphModel(Model):
         stellar: StellarModel = self.submodels["StellarModel"]  # type: ignore[assignment]
         dm: DMModel = self.submodels["DMModel"]  # type: ignore[assignment]
         ani: AnisotropyModel = self.submodels["AnisotropyModel"]  # type: ignore[assignment]
-        dm_mass_method = self._resolve_dm_mass_method(dm, use_analytic_dm)
+        dm_mass_method = self._resolve_dm_mass_method(dm, dm_mass_method)
 
         re_pc = jnp.asarray(params["re_pc"], dtype=dtype)
         r_min = jnp.maximum(
@@ -1290,7 +1308,7 @@ class DSphModel(Model):
         constant_kernel_backend: str = DEFAULT_CONSTANT_KERNEL_BACKEND,
         u_min_eps: float = 1e-6,
         r_min_factor: float = 0.5,
-        use_analytic_dm: Optional[bool] = None,
+        dm_mass_method: str = "auto",
     ) -> jnp.ndarray:
         """Compute sigma_los^2(R) via the requested backend.
 
@@ -1301,10 +1319,10 @@ class DSphModel(Model):
         ``jit`` controls whether a cached ``jax.jit`` wrapper is used around the
         selected solver. ``None`` defaults to the cached JIT path.
 
-        ``use_analytic_dm=None`` (the default) follows the DM model's
-        autodiff-safe mass method: analytic for NFW and numeric for Zhao. Set
-        it to ``True`` to request an analytic mass explicitly, or ``False`` to
-        force the numeric path.
+        ``dm_mass_method`` controls the dark-matter enclosed-mass backend and
+        must be one of ``"auto"``, ``"analytic"``, or ``"numeric"``. The
+        default ``"auto"`` follows the DM model's autodiff-safe choice:
+        analytic for NFW and numeric for Zhao.
         """
         backend_key = str(backend).strip().lower()
         ani = self.submodels["AnisotropyModel"]  # type: ignore[index]
@@ -1323,8 +1341,7 @@ class DSphModel(Model):
 
         use_jit = DEFAULT_SIGMALOS2_JIT if jit is None else bool(jit)
         dm: DMModel = self.submodels["DMModel"]  # type: ignore[assignment]
-        dm_mass_method = self._resolve_dm_mass_method(dm, use_analytic_dm)
-        resolved_use_analytic_dm = dm_mass_method == "analytic"
+        dm_mass_method = self._resolve_dm_mass_method(dm, dm_mass_method)
 
         resolved_n_u = _default_sigmalos2_n_u() if n_u is None else int(n_u)
         resolved_n_r = _default_sigmalos2_n_r() if n_r is None else int(n_r)
@@ -1346,7 +1363,7 @@ class DSphModel(Model):
                     n_r=resolved_n_r,
                     u_max=resolved_u_max,
                     r_min_factor=r_min_factor,
-                    use_analytic_dm=resolved_use_analytic_dm,
+                    dm_mass_method=dm_mass_method,
                 )
             return self.sigmalos2_kernel(
                 R_value,
@@ -1356,7 +1373,7 @@ class DSphModel(Model):
                 u_max=resolved_u_max,
                 constant_kernel_backend=constant_kernel_backend_key,
                 u_min_eps=u_min_eps,
-                use_analytic_dm=resolved_use_analytic_dm,
+                dm_mass_method=dm_mass_method,
             )
 
         if not use_jit:

--- a/tests/test_dm_mass_consistency.py
+++ b/tests/test_dm_mass_consistency.py
@@ -117,7 +117,7 @@ class TestDSSigmaLos2DMEquivalence(unittest.TestCase):
                 params=params_nfw,
                 n_u=192,
                 u_max=1500.0,
-                use_analytic_dm=True,
+                dm_mass_method="analytic",
             ),
             dtype=np.float64,
         )
@@ -127,7 +127,7 @@ class TestDSSigmaLos2DMEquivalence(unittest.TestCase):
                 params=params_zhao,
                 n_u=192,
                 u_max=1500.0,
-                use_analytic_dm=True,
+                dm_mass_method="analytic",
             ),
             dtype=np.float64,
         )

--- a/tests/test_dm_mass_method_api.py
+++ b/tests/test_dm_mass_method_api.py
@@ -7,7 +7,6 @@ capability-driven ``auto`` policy.
 
 import inspect
 
-import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -109,23 +108,3 @@ def test_invalid_dm_mass_method_is_rejected_consistently():
             u_max=300.0,
             dm_mass_method="not-a-method",
         )
-
-
-def test_default_zhao_jeans_path_remains_differentiable():
-    dsph = _zhao_dsph()
-    params = _zhao_params()
-    R = jnp.asarray([20.0, 100.0], dtype=jnp.float32)
-
-    def objective(a):
-        sigma2 = dsph.sigmalos2(
-            R,
-            params={**params, "a": a},
-            backend="kernel",
-            jit=False,
-            n_u=64,
-            u_max=400.0,
-        )
-        return jnp.sum(sigma2)
-
-    grad_a = jax.grad(objective)(jnp.asarray(params["a"], dtype=R.dtype))
-    assert np.isfinite(np.asarray(grad_a)).all()

--- a/tests/test_dm_mass_method_api.py
+++ b/tests/test_dm_mass_method_api.py
@@ -1,0 +1,131 @@
+"""Regression contract for NumPyro DM enclosed-mass method selection.
+
+This follow-up to PR #29 intentionally describes the pre-v0.1 public API we
+want to preserve going forward: a method-style ``dm_mass_method`` option and a
+capability-driven ``auto`` policy.
+"""
+
+import inspect
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jeanspy.model_numpyro import (
+    ConstantAnisotropyModel,
+    DSphModel,
+    DMModel,
+    NFWModel,
+    PlummerModel,
+    ZhaoModel,
+)
+
+
+def _zhao_dsph() -> DSphModel:
+    return DSphModel(
+        submodels={
+            "StellarModel": PlummerModel(),
+            "DMModel": ZhaoModel(),
+            "AnisotropyModel": ConstantAnisotropyModel(),
+        }
+    )
+
+
+def _zhao_params() -> dict[str, float]:
+    return {
+        "re_pc": 220.0,
+        "rs_pc": 900.0,
+        "rhos_Msunpc3": 8e-3,
+        "a": 1.2,
+        "b": 4.2,
+        "g": 0.6,
+        "r_t_pc": 8000.0,
+        "beta_ani": 0.2,
+        "vmem_kms": 0.0,
+    }
+
+
+def test_public_jeans_api_uses_dm_mass_method_not_boolean_flag():
+    for method_name in ("sigmalos2", "sigmalos2_kernel", "sigmalos2_abel"):
+        signature = inspect.signature(getattr(DSphModel, method_name))
+        assert "dm_mass_method" in signature.parameters
+        assert signature.parameters["dm_mass_method"].default == "auto"
+        assert "use_analytic_dm" not in signature.parameters
+
+
+def test_auto_selection_is_capability_driven():
+    assert hasattr(DMModel, "analytic_enclosed_mass_autodiff_safe")
+    assert DMModel.analytic_enclosed_mass_autodiff_safe is False
+    assert NFWModel.analytic_enclosed_mass_autodiff_safe is True
+    assert ZhaoModel.analytic_enclosed_mass_autodiff_safe is False
+
+
+def test_nfw_auto_matches_analytic_and_zhao_auto_matches_numeric():
+    r = jnp.asarray(np.geomspace(1.0, 3000.0, 32), dtype=jnp.float32)
+
+    nfw = NFWModel()
+    nfw_params = {
+        "rs_pc": 900.0,
+        "rhos_Msunpc3": 8e-3,
+        "r_t_pc": 8000.0,
+    }
+    np.testing.assert_allclose(
+        np.asarray(nfw.enclosed_mass(r, method="auto", params=nfw_params)),
+        np.asarray(nfw.enclosed_mass(r, method="analytic", params=nfw_params)),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+    zhao = ZhaoModel()
+    zhao_params = {
+        "rs_pc": 900.0,
+        "rhos_Msunpc3": 8e-3,
+        "a": 1.2,
+        "b": 4.2,
+        "g": 0.6,
+        "r_t_pc": 8000.0,
+    }
+    np.testing.assert_allclose(
+        np.asarray(zhao.enclosed_mass(r, method="auto", params=zhao_params)),
+        np.asarray(zhao.enclosed_mass(r, method="numeric", params=zhao_params)),
+        rtol=0.0,
+        atol=0.0,
+    )
+
+
+def test_invalid_dm_mass_method_is_rejected_consistently():
+    dsph = _zhao_dsph()
+    params = _zhao_params()
+    R = jnp.asarray([20.0, 100.0], dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="dm_mass_method"):
+        dsph.sigmalos2(
+            R,
+            params=params,
+            backend="kernel",
+            jit=False,
+            n_u=32,
+            u_max=300.0,
+            dm_mass_method="not-a-method",
+        )
+
+
+def test_default_zhao_jeans_path_remains_differentiable():
+    dsph = _zhao_dsph()
+    params = _zhao_params()
+    R = jnp.asarray([20.0, 100.0], dtype=jnp.float32)
+
+    def objective(a):
+        sigma2 = dsph.sigmalos2(
+            R,
+            params={**params, "a": a},
+            backend="kernel",
+            jit=False,
+            n_u=64,
+            u_max=400.0,
+        )
+        return jnp.sum(sigma2)
+
+    grad_a = jax.grad(objective)(jnp.asarray(params["a"], dtype=R.dtype))
+    assert np.isfinite(np.asarray(grad_a)).all()

--- a/tests/test_model_backend_consistency.py
+++ b/tests/test_model_backend_consistency.py
@@ -567,7 +567,7 @@ class TestDSphConsistencyAgainstClassical(unittest.TestCase):
                     backend="kernel",
                     n_u=1024,
                     u_max=5000.0,
-                    use_analytic_dm=True,
+                    dm_mass_method="analytic",
                 )
                 _assert_allclose(
                     self,
@@ -602,7 +602,7 @@ class TestDSphConsistencyAgainstClassical(unittest.TestCase):
             backend="kernel",
             n_u=768,
             u_max=3000.0,
-            use_analytic_dm=True,
+            dm_mass_method="analytic",
         )
         _assert_allclose(
             self,

--- a/tests/test_model_numpyro.py
+++ b/tests/test_model_numpyro.py
@@ -609,7 +609,7 @@ class TestModelNumPyro(unittest.TestCase):
                         params=true,
                         n_u=512,
                         u_max=3000.0,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     )
                 )
                 s2_ref = np.array(dsph_ref.sigmalos2_dequad(R, n=1024, n_kernel=128))
@@ -656,7 +656,7 @@ class TestModelNumPyro(unittest.TestCase):
                 params=params_base,
                 n_u=192,
                 u_max=1500.0,
-                use_analytic_dm=True,
+                dm_mass_method="analytic",
             ),
             dtype=np.float64,
         )
@@ -666,7 +666,7 @@ class TestModelNumPyro(unittest.TestCase):
                 params=params_zhao,
                 n_u=192,
                 u_max=1500.0,
-                use_analytic_dm=True,
+                dm_mass_method="analytic",
             ),
             dtype=np.float64,
         )
@@ -719,7 +719,7 @@ class TestModelNumPyro(unittest.TestCase):
                 params=p,
                 n_u=192,
                 u_max=1500.0,
-                use_analytic_dm=True,
+                dm_mass_method="analytic",
             )
 
         @jax.jit
@@ -729,7 +729,7 @@ class TestModelNumPyro(unittest.TestCase):
                 params=p,
                 n_u=192,
                 u_max=1500.0,
-                use_analytic_dm=True,
+                dm_mass_method="analytic",
             )
 
         s2_nfw = np.asarray(_sig2_nfw(jnp.asarray(R_pc), params_nfw), dtype=np.float64)
@@ -762,7 +762,7 @@ class TestModelNumPyro(unittest.TestCase):
                         backend="kernel",
                         n_u=224,
                         u_max=1600.0,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     ),
                     dtype=np.float64,
                 )
@@ -774,7 +774,7 @@ class TestModelNumPyro(unittest.TestCase):
                         n_r=896,
                         u_max=1600.0,
                         r_min_factor=0.35,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     ),
                     dtype=np.float64,
                 )
@@ -787,7 +787,7 @@ class TestModelNumPyro(unittest.TestCase):
                         n_r=896,
                         u_max=1600.0,
                         r_min_factor=0.35,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     ),
                     dtype=np.float64,
                 )
@@ -837,7 +837,7 @@ class TestModelNumPyro(unittest.TestCase):
                         backend="kernel",
                         n_u=192,
                         u_max=1400.0,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     )
                 )
                 abel_fn = jax.jit(
@@ -848,7 +848,7 @@ class TestModelNumPyro(unittest.TestCase):
                         n_r=640,
                         u_max=1400.0,
                         r_min_factor=0.35,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     )
                 )
                 auto_fn = jax.jit(
@@ -860,7 +860,7 @@ class TestModelNumPyro(unittest.TestCase):
                         n_r=640,
                         u_max=1400.0,
                         r_min_factor=0.35,
-                        use_analytic_dm=True,
+                        dm_mass_method="analytic",
                     )
                 )
 


### PR DESCRIPTION
Follow-up to #29 and implementation target for #31.

## What changed

- Replaced `use_analytic_dm: Optional[bool]` with `dm_mass_method="auto"|"analytic"|"numeric"` on `DSphModel.sigmalos2`, `sigmalos2_kernel`, and `sigmalos2_abel`.
- Made `DMModel.enclosed_mass(method="auto")` capability-driven through `analytic_enclosed_mass_autodiff_safe`.
  - NFW: analytic enclosed mass is autodiff-safe, so `auto` selects analytic.
  - General Zhao: analytic `betainc` shape-parameter gradients are not JAX-safe, so `auto` selects numeric.
- Preserved explicit analytic/numeric overrides.
- Added consistent validation for invalid `dm_mass_method` values.
- Updated README and existing regression/benchmark calls to the new API.
- Added API contract tests for the public signatures and auto-selection behavior.
- Kept the existing Zhao `jax.grad` regression as the single differentiability test (duplicate follow-up test removed after review).

## Validation

Before the final test-deduplication commit, focused tests reported `40 passed, 3 skipped, 9 warnings, 37 subtests passed` and the full suite reported `163 passed, 3 skipped, 37 subtests passed`. The final commit only removes the duplicate gradient regression; GitHub Actions is rerunning on that head.

Closes #31