### PR TITLE
Add analytic eta=2 Baes anisotropy kernel

### DIFF
--- a/src/jeanspy/analytic_kernels.py
+++ b/src/jeanspy/analytic_kernels.py
@@ -1,0 +1,179 @@
+"""Analytic and semi-analytic anisotropy kernels.
+
+This module contains reference implementations of closed-form kernel
+representations that are useful for validating the numerical Jeans solvers.
+They intentionally live outside the JAX backend so that the special-function
+identities can be evaluated with SciPy at double precision.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.integrate import quad_vec
+
+
+def _appell_f1_1_b1_b2_3half(
+    x,
+    y,
+    b1,
+    b2,
+    *,
+    epsabs: float = 1.0e-11,
+    epsrel: float = 1.0e-11,
+):
+    r"""Evaluate ``F1(1; b1, b2; 3/2; x, y)`` for real ``0 <= x,y < 1``.
+
+    The standard Euler representation of Appell's first hypergeometric
+    function simplifies for ``a=1`` and ``c=3/2``.  After the substitution
+    ``t = 1-s^2`` it becomes
+
+    .. math::
+
+        F_1(1;b_1,b_2;3/2;x,y)
+        = \int_0^1
+          (1-x+x s^2)^{-b_1}
+          (1-y+y s^2)^{-b_2}\,ds.
+
+    This form has no endpoint square-root singularity.  ``quad_vec`` evaluates
+    all broadcast array elements together, which makes this a convenient
+    high-accuracy reference evaluator even though SciPy does not currently
+    expose Appell ``F1`` directly.
+    """
+
+    x_arr, y_arr, b1_arr, b2_arr = np.broadcast_arrays(
+        np.asarray(x, dtype=float),
+        np.asarray(y, dtype=float),
+        np.asarray(b1, dtype=float),
+        np.asarray(b2, dtype=float),
+    )
+
+    if np.any(~np.isfinite(x_arr)) or np.any(~np.isfinite(y_arr)):
+        raise ValueError("Appell F1 arguments must be finite.")
+    if np.any(x_arr < 0.0) or np.any(x_arr >= 1.0):
+        raise ValueError("Require 0 <= x < 1 for the eta=2 kernel representation.")
+    if np.any(y_arr < 0.0) or np.any(y_arr >= 1.0):
+        raise ValueError("Require 0 <= y < 1 for the eta=2 kernel representation.")
+
+    def integrand(s):
+        s2 = s * s
+        factor_x = (1.0 - x_arr) + x_arr * s2
+        factor_y = (1.0 - y_arr) + y_arr * s2
+        return np.power(factor_x, -b1_arr) * np.power(factor_y, -b2_arr)
+
+    value, _ = quad_vec(
+        integrand,
+        0.0,
+        1.0,
+        epsabs=float(epsabs),
+        epsrel=float(epsrel),
+    )
+    return np.asarray(value, dtype=float)
+
+
+def baes_eta2_kernel_appell(
+    u,
+    R_pc,
+    *,
+    beta_0,
+    beta_inf,
+    r_a,
+    epsabs: float = 1.0e-11,
+    epsrel: float = 1.0e-11,
+):
+    r"""Baes--van Hese LOS kernel for fixed transition exponent ``eta=2``.
+
+    For
+
+    .. math::
+
+        \beta(r)=\frac{\beta_0+\beta_\infty(r/r_a)^2}
+                       {1+(r/r_a)^2},
+
+    define
+
+    .. math::
+
+        p=\beta_0,\qquad q=\beta_\infty-\beta_0,\qquad
+        a=\frac{r_a}{R},
+
+    and
+
+    .. math::
+
+        z_1=1-u^{-2},\qquad
+        z_2=\frac{u^2-1}{u^2+a^2}.
+
+    The Jeans projection kernel used by :mod:`jeanspy.model_numpyro` is then
+
+    .. math::
+
+        K(u,R)=\sqrt{1-u^{-2}}\left[
+        F_1(1;p,q;3/2;z_1,z_2)
+        -\frac{p}{u^2}F_1(1;p+1,q;3/2;z_1,z_2)
+        -\frac{q}{u^2+a^2}F_1(1;p,q+1;3/2;z_1,z_2)
+        \right].
+
+    The expression follows by setting ``t=sqrt(r^2/R^2-1)`` in the inner
+    projection integral and using the Appell ``F1`` antiderivative.  All Appell
+    arguments lie in ``[0,1)`` for ``u>=1``, ``R>0`` and ``r_a>0``.
+
+    Notes
+    -----
+    This routine is intended first as a high-accuracy reference implementation.
+    It evaluates the Appell functions through their nonsingular Euler integral
+    because SciPy/JAX do not provide a native ``F1`` implementation.  The
+    closed form itself is independent of that numerical evaluation strategy.
+    """
+
+    u_arr, R_arr, beta0_arr, betainf_arr, ra_arr = np.broadcast_arrays(
+        np.asarray(u, dtype=float),
+        np.asarray(R_pc, dtype=float),
+        np.asarray(beta_0, dtype=float),
+        np.asarray(beta_inf, dtype=float),
+        np.asarray(r_a, dtype=float),
+    )
+
+    if np.any(~np.isfinite(u_arr)) or np.any(~np.isfinite(R_arr)):
+        raise ValueError("u and R_pc must be finite.")
+    if np.any(~np.isfinite(beta0_arr)) or np.any(~np.isfinite(betainf_arr)):
+        raise ValueError("beta_0 and beta_inf must be finite.")
+    if np.any(~np.isfinite(ra_arr)):
+        raise ValueError("r_a must be finite.")
+    if np.any(u_arr < 1.0):
+        raise ValueError("Require u >= 1 for the LOS kernel.")
+    if np.any(R_arr <= 0.0):
+        raise ValueError("Require R_pc > 0 for the LOS kernel.")
+    if np.any(ra_arr <= 0.0):
+        raise ValueError("Require r_a > 0 for the LOS kernel.")
+
+    p = beta0_arr
+    q = betainf_arr - beta0_arr
+    u2 = u_arr * u_arr
+    a2 = (ra_arr / R_arr) ** 2
+
+    z1 = np.maximum(1.0 - 1.0 / u2, 0.0)
+    z2 = np.maximum((u2 - 1.0) / (u2 + a2), 0.0)
+
+    # Avoid roundoff producing exactly one for finite but very large u.
+    one_minus = np.nextafter(1.0, 0.0)
+    z1 = np.minimum(z1, one_minus)
+    z2 = np.minimum(z2, one_minus)
+
+    f00 = _appell_f1_1_b1_b2_3half(
+        z1, z2, p, q, epsabs=epsabs, epsrel=epsrel
+    )
+    f10 = _appell_f1_1_b1_b2_3half(
+        z1, z2, p + 1.0, q, epsabs=epsabs, epsrel=epsrel
+    )
+    f01 = _appell_f1_1_b1_b2_3half(
+        z1, z2, p, q + 1.0, epsabs=epsabs, epsrel=epsrel
+    )
+
+    prefactor = np.sqrt(z1)
+    kernel = prefactor * (
+        f00 - (p / u2) * f10 - (q / (u2 + a2)) * f01
+    )
+    return np.where(u_arr == 1.0, 0.0, kernel)
+
+
+__all__ = ["baes_eta2_kernel_appell"]

--- a/tests/test_baes_eta2_analytic_kernel.py
+++ b/tests/test_baes_eta2_analytic_kernel.py
@@ -1,0 +1,204 @@
+import numpy as np
+from scipy.integrate import quad
+
+import jax.numpy as jnp
+
+from jeanspy.analytic_kernels import baes_eta2_kernel_appell
+from jeanspy.model_numpyro import (
+    BaesAnisotropyModel,
+    ConstantAnisotropyModel,
+    DSphModel,
+    NFWModel,
+    OsipkovMerrittModel,
+    PlummerModel,
+)
+
+
+def _baes_eta2_kernel_direct(u, R, beta_0, beta_inf, r_a):
+    """Independent scalar reference from the original kernel definition."""
+
+    def beta(r):
+        x = (r / r_a) ** 2
+        return (beta_0 + beta_inf * x) / (1.0 + x)
+
+    def f(r):
+        x = (r / r_a) ** 2
+        return r ** (2.0 * beta_0) * (1.0 + x) ** (beta_inf - beta_0)
+
+    if u == 1.0:
+        return 0.0
+
+    t_max = np.sqrt(u * u - 1.0)
+
+    def integrand(t):
+        u_int = np.sqrt(1.0 + t * t)
+        r_int = R * u_int
+        return (1.0 - beta(r_int) / (u_int * u_int)) / f(r_int)
+
+    inner, _ = quad(integrand, 0.0, t_max, epsabs=1.0e-12, epsrel=1.0e-12)
+    return f(R * u) / u * inner
+
+
+def test_baes_eta2_appell_matches_original_kernel_integral():
+    cases = [
+        (1.15, 80.0, -0.5, 0.6, 250.0),
+        (2.5, 150.0, 0.0, 0.8, 300.0),
+        (8.0, 60.0, -1.5, 0.2, 120.0),
+        (25.0, 300.0, 0.25, 0.75, 100.0),
+    ]
+
+    for u, R, beta_0, beta_inf, r_a in cases:
+        analytic = float(
+            baes_eta2_kernel_appell(
+                u,
+                R,
+                beta_0=beta_0,
+                beta_inf=beta_inf,
+                r_a=r_a,
+            )
+        )
+        direct = _baes_eta2_kernel_direct(u, R, beta_0, beta_inf, r_a)
+        np.testing.assert_allclose(analytic, direct, rtol=2.0e-10, atol=2.0e-12)
+
+
+def test_baes_eta2_appell_matches_existing_jax_kernel():
+    u = np.geomspace(1.0 + 5.0e-4, 30.0, 48)[None, :]
+    R = np.asarray([50.0, 180.0])[:, None]
+    ani = BaesAnisotropyModel()
+
+    parameter_sets = [
+        {"beta_0": -0.5, "beta_inf": 0.6, "r_a": 250.0, "eta": 2.0},
+        {"beta_0": 0.0, "beta_inf": 0.8, "r_a": 300.0, "eta": 2.0},
+        {"beta_0": -2.0, "beta_inf": 0.2, "r_a": 120.0, "eta": 2.0},
+    ]
+
+    for params in parameter_sets:
+        analytic = baes_eta2_kernel_appell(
+            u,
+            R,
+            beta_0=params["beta_0"],
+            beta_inf=params["beta_inf"],
+            r_a=params["r_a"],
+        )
+        numerical = np.asarray(
+            ani.kernel(
+                jnp.asarray(u),
+                jnp.asarray(R),
+                params=params,
+                n_kernel=512,
+            )
+        )
+
+        assert np.isfinite(analytic).all()
+        assert np.isfinite(numerical).all()
+        np.testing.assert_allclose(analytic, numerical, rtol=8.0e-3, atol=3.0e-5)
+
+
+def test_baes_eta2_appell_reproduces_constant_and_osipkov_limits():
+    u = np.geomspace(1.0 + 1.0e-4, 20.0, 80)[None, :]
+    R = np.asarray([60.0, 200.0])[:, None]
+
+    beta_const = 0.3
+    analytic_const = baes_eta2_kernel_appell(
+        u,
+        R,
+        beta_0=beta_const,
+        beta_inf=beta_const,
+        r_a=170.0,
+    )
+    const_model = ConstantAnisotropyModel()
+    constant = np.asarray(
+        const_model.kernel(
+            jnp.asarray(u),
+            jnp.asarray(R),
+            params={"beta_ani": beta_const},
+            backend="scipy",
+        )
+    )
+    constant = np.broadcast_to(constant, analytic_const.shape)
+    np.testing.assert_allclose(analytic_const, constant, rtol=2.0e-5, atol=2.0e-7)
+
+    r_a = 170.0
+    analytic_om = baes_eta2_kernel_appell(
+        u,
+        R,
+        beta_0=0.0,
+        beta_inf=1.0,
+        r_a=r_a,
+    )
+    om_model = OsipkovMerrittModel()
+    om = np.asarray(
+        om_model.kernel(
+            jnp.asarray(u),
+            jnp.asarray(R),
+            params={"r_a": r_a},
+        )
+    )
+    np.testing.assert_allclose(analytic_om, om, rtol=2.0e-5, atol=2.0e-7)
+
+
+class _BaesEta2AppellForTest(BaesAnisotropyModel):
+    """Test-only adapter that injects the analytic kernel into DSphModel."""
+
+    def kernel(self, u, R_pc, *, params, n_kernel=128):
+        del n_kernel
+        value = baes_eta2_kernel_appell(
+            np.asarray(u),
+            np.asarray(R_pc),
+            beta_0=float(np.asarray(params["beta_0"])),
+            beta_inf=float(np.asarray(params["beta_inf"])),
+            r_a=float(np.asarray(params["r_a"])),
+        )
+        return jnp.asarray(value, dtype=jnp.result_type(u, R_pc))
+
+
+def test_baes_eta2_appell_sigmalos_matches_kernel_free_abel_solver():
+    model = DSphModel(
+        submodels={
+            "StellarModel": PlummerModel(),
+            "DMModel": NFWModel(),
+            "AnisotropyModel": _BaesEta2AppellForTest(),
+        }
+    )
+    params = {
+        "re_pc": 220.0,
+        "rs_pc": 1100.0,
+        "rhos_Msunpc3": 7.5e-3,
+        "r_t_pc": 9000.0,
+        "beta_0": 0.0,
+        "beta_inf": 0.65,
+        "r_a": 300.0,
+        "eta": 2.0,
+        "vmem_kms": 0.0,
+    }
+    R = jnp.asarray([50.0, 120.0, 300.0])
+
+    sigma2_kernel = np.asarray(
+        model.sigmalos2(
+            R,
+            params=params,
+            backend="kernel",
+            jit=False,
+            n_u=512,
+            n_kernel=128,
+            u_max=2000.0,
+            use_analytic_dm=True,
+        )
+    )
+    sigma2_abel = np.asarray(
+        model.sigmalos2(
+            R,
+            params=params,
+            backend="abel",
+            jit=False,
+            n_r=1024,
+            u_max=2000.0,
+            use_analytic_dm=True,
+        )
+    )
+
+    assert np.isfinite(sigma2_kernel).all()
+    assert np.isfinite(sigma2_abel).all()
+    assert np.all(sigma2_kernel > 0.0)
+    assert np.all(sigma2_abel > 0.0)
+    np.testing.assert_allclose(sigma2_kernel, sigma2_abel, rtol=6.0e-2, atol=2.0e-3)


### PR DESCRIPTION
## Summary

- add a high-accuracy analytic representation of the Baes--van Hese anisotropy kernel for fixed `eta=2`
- express the kernel in terms of Appell `F1(1; b1, b2; 3/2; x, y)` with arguments mapped to `[0, 1)`
- evaluate `F1` through its nonsingular Euler representation using SciPy `quad_vec`
- keep the existing JAX numerical Baes kernel unchanged; the new implementation is initially a reference/validation path

## Validation

The new tests compare the analytic kernel against:

1. an independent direct evaluation of the original inner kernel integral
2. the existing JAX numerical Baes kernel
3. the known constant-anisotropy and Osipkov--Merritt limits
4. the kernel-free Jeans + Abel `sigmalos2` solver for a representative Plummer + NFW dwarf model

Additional independent checks reproduce the constant-anisotropy and Osipkov--Merritt analytic limits at roughly machine precision in double precision.

## CI

GitHub Actions is green on Python 3.12 and 3.13 for both the base-install smoke tests and the full NumPyro CPU test suite.