### PR TITLE
Remove accidental debug output from inpoly

### DIFF
--- a/src/jeanspy/cmd_utilities.py
+++ b/src/jeanspy/cmd_utilities.py
@@ -1,23 +1,15 @@
 import numpy as np
 
-def inpoly(x,y,xs_vertex,ys_vertex):
-    ''' 
-    xs_vertex[:], ys_vertex[:]: polygon
-    x, y: point
-    '''
-    x1 = xs_vertex[:,np.newaxis]
-    y1 = ys_vertex[:,np.newaxis]
-    x2 = np.roll(x1,-1)
-    y2 = np.roll(y1,-1)
-    print(np.array([x1[:,0],y1[:,0]]))
-    print(np.array([x2[:,0],y2[:,0]]))
-    ispointbetweenithsep = (x1-x)*(x2-x)<0
-    ispointaboveithsep = (x2-x1)*((x2-x1)*(y-y1)-(y2-y1)*(x-x1))>0
-    numofsepbelowpoint = (ispointbetweenithsep*ispointaboveithsep).sum(axis=0)
-    isoddnumbersepabovepoint = (numofsepbelowpoint%2 == 1)
-    #print(ispointbetweenithsep)
-    #print(ispointaboveithsep)
-    #print(numofsepbelowpoint)
-    #print(isoddnumbersepabovepoint)
-    return isoddnumbersepabovepoint
 
+def inpoly(x, y, xs_vertex, ys_vertex):
+    """Return whether each point is inside the polygon vertices."""
+    x1 = xs_vertex[:, np.newaxis]
+    y1 = ys_vertex[:, np.newaxis]
+    x2 = np.roll(x1, -1)
+    y2 = np.roll(y1, -1)
+    ispointbetweenithsep = (x1 - x) * (x2 - x) < 0
+    ispointaboveithsep = (x2 - x1) * (
+        (x2 - x1) * (y - y1) - (y2 - y1) * (x - x1)
+    ) > 0
+    numofsepbelowpoint = (ispointbetweenithsep * ispointaboveithsep).sum(axis=0)
+    return numofsepbelowpoint % 2 == 1

--- a/tests/test_cmd_utilities.py
+++ b/tests/test_cmd_utilities.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+from jeanspy.cmd_utilities import inpoly
+
+
+def test_inpoly_has_no_stdout_side_effect(capsys):
+    xs_vertex = np.array([0.0, 1.0, 1.0, 0.0])
+    ys_vertex = np.array([0.0, 0.0, 1.0, 1.0])
+    x = np.array([0.5, 1.5])
+    y = np.array([0.5, 0.5])
+
+    result = inpoly(x, y, xs_vertex, ys_vertex)
+
+    np.testing.assert_array_equal(result, np.array([True, False]))
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""


### PR DESCRIPTION
## Summary

Remove unconditional debug `print()` calls from `jeanspy.cmd_utilities.inpoly()` and add a focused regression test.

This is intentionally separate from the broader v0.1.0 public-API decision for historical utility modules (#36): regardless of whether `cmd_utilities` remains public, calling a library helper should not dump internal polygon arrays to stdout.

## Changes

- remove the two unconditional array prints and stale commented debug prints;
- lightly clarify the function formatting/docstring without changing the crossing-number calculation;
- add a square-polygon inside/outside regression test that also asserts stdout/stderr remain empty.