### PR TITLE
Define and enforce sigmalos2 kernel accuracy targets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba8058253d602b5173b7dd # v7.0.1
         with:
           persist-credentials: false
 
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba8058253d602b5173b7dd # v7.0.1
         with:
           persist-credentials: false
 
@@ -74,9 +74,9 @@ jobs:
         if: matrix.python-version == '3.12'
         run: JAX_ENABLE_X64=true uv run --python "${{ matrix.python-version }}" python scripts/benchmark_eta2_sqrtlog_stress.py
 
-      - name: Benchmark public sqrtlog defaults
+      - name: Check sigmalos2 accuracy contract
         if: matrix.python-version == '3.12'
-        run: JAX_ENABLE_X64=true uv run --python "${{ matrix.python-version }}" python scripts/benchmark_sigmalos2_sqrtlog_defaults.py
+        run: JAX_ENABLE_X64=true uv run --python "${{ matrix.python-version }}" python scripts/benchmark_sigmalos2_accuracy_contract.py
 
       - name: Generate Sérsic visualization
         run: uv run --python "${{ matrix.python-version }}" python scripts/plot_sersic_pr_summary.py artifacts/sersic_deprojection_summary

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba8058253d602b5173b7dd # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba8058253d602b5173b7dd # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/README.md
+++ b/README.md
@@ -257,9 +257,61 @@ kernel = ConstantAnisotropyModel().kernel(
 )
 ```
 
-On GPU float32, `model_numpyro` defaults to `n_u=1024` for the kernel solver. If you need tighter agreement with a high-resolution reference, raise `n_u` explicitly on the relevant `sigmalos2()` call.
+### Kernel `sigmalos2` numerical-accuracy contract
 
-To reproduce the backend and precision comparison used during development, run:
+For calls resolved to `backend="kernel"` with the default `sqrtlog` outer
+transform, the maintained numerical target is a maximum relative error of
+`1e-3` against a high-resolution float64 kernel reference.  The regression
+metric uses a floor of `max(1e-12, 1e-9 * max(abs(reference)))` so values that
+are numerically negligible do not dominate the relative-error statistic.
+
+The deterministic stress benchmark samples the following dSph-oriented
+envelope with a Plummer tracer and NFW halo:
+
+- `0.005 <= R/Re <= 10`;
+- `0.05 <= rs/Re <= 100` and the standard benchmark truncation `r_t/Re = 40`;
+- constant anisotropy from `beta=-9` through `beta=0.98`;
+- Osipkov-Merritt transitions with `0.005 <= r_a/Re <= 50`;
+- Baes-van Hese models with `0.1 <= eta <= 10`, anisotropy edges down to
+  `beta=-9` and up to `beta=0.98`, and `0.005 <= r_a/Re <= 50`.
+
+This is a tested numerical envelope, not a proof for every continuous point in
+that box or for arbitrary tracer/halo profiles.  Zhao halos, more extreme
+anisotropy, `eta > 10`, substantially more extended tails, or radii outside the
+sampled range should be convergence-tested explicitly.
+
+The kernel defaults are tuned to the tail-dominated error found in the stress
+study: CPU float64/float32 use `n_u=128`, GPU-oriented float32 keeps
+`n_u=1024`, and both use `u_max=10000`.  The Baes inner quadrature remains
+`n_kernel=32`; constant-anisotropy JAX kernels use 32 nodes on CPU and 64 on
+GPU float32.  Increasing `n_u` at fixed, too-small `u_max` does not repair tail
+truncation, so for extended models increase `u_max` first and then increase
+`n_u` if the denser interval still changes the result appreciably.
+
+A practical convergence check is to recompute the result after increasing
+`u_max` and then doubling `n_u`.  For generic Baes models, increase `n_kernel`
+only if the inner-kernel quadrature itself is suspected.  The Abel solver is a
+useful independent cross-check, but it has a separate radial discretization
+controlled by `n_r`; the `1e-3` contract above does not automatically apply to
+an `auto` call that resolves to the Abel backend.
+
+Run the compact CI regression set with:
+
+```bash
+JAX_ENABLE_X64=true python scripts/benchmark_sigmalos2_accuracy_contract.py
+```
+
+Run the complete sampled prior-edge matrix with:
+
+```bash
+JAX_ENABLE_X64=true python scripts/benchmark_sigmalos2_accuracy_contract.py --full
+```
+
+GitHub-hosted CI has no GPU.  The benchmark therefore evaluates the
+GPU-oriented float32 numerical grid on CPU as an arithmetic/accuracy proxy;
+GPU wall-clock performance must be measured on actual accelerator hardware.
+
+To reproduce the broader backend and precision comparison used during development, run:
 
 ```bash
 python scripts/compare_runtime_modes.py

--- a/scripts/benchmark_sigmalos2_accuracy_contract.py
+++ b/scripts/benchmark_sigmalos2_accuracy_contract.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+# The benchmark needs float64 references.  Float32 candidates are still evaluated
+# with float32 arrays in the same process so they can be compared directly.
+os.environ.setdefault("JEANSPY_JAX_PLATFORM", "cpu")
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("JAX_ENABLE_X64", "true")
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+
+
+ACCURACY_TARGET = 1.0e-3
+RELATIVE_FLOOR_FRACTION = 1.0e-9
+ABSOLUTE_FLOOR = 1.0e-12
+REFERENCE_N_U = 1024
+REFERENCE_N_KERNEL = 256
+REFERENCE_U_MAX = 1.0e5
+CPU_N_U = 128
+GPU_X32_N_U = 1024
+DEFAULT_U_MAX = 1.0e4
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    anisotropy: str
+    rs_over_re: float
+    r_t_over_re: float = 40.0
+    beta_ani: float = 0.0
+    beta_0: float = 0.0
+    beta_inf: float = 0.0
+    r_a_over_re: float = 1.0
+    eta: float = 2.0
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    dtype_name: str
+    n_u: int
+    u_max: float
+    constant_n_kernel: int
+    baes_n_kernel: int
+    public_cpu_defaults: bool
+
+
+PROFILES = (
+    Profile("cpu-float64", "float64", CPU_N_U, DEFAULT_U_MAX, 32, 32, True),
+    Profile("cpu-float32", "float32", CPU_N_U, DEFAULT_U_MAX, 32, 32, True),
+    # GitHub-hosted CI has no GPU.  This profile reproduces the numerical grid and
+    # float32 arithmetic of the GPU-oriented defaults on CPU; its runtime is not a
+    # GPU performance measurement.
+    Profile(
+        "gpu-float32-numerical-proxy",
+        "float32",
+        GPU_X32_N_U,
+        DEFAULT_U_MAX,
+        64,
+        32,
+        False,
+    ),
+)
+
+
+CI_CASES = (
+    Case("constant-near-radial-broad", "constant", 100.0, beta_ani=0.98),
+    Case("constant-tangential", "constant", 5.0, beta_ani=-9.0),
+    Case("om-radial-broad", "om", 100.0, r_a_over_re=0.05),
+    Case("om-outer-transition", "om", 5.0, r_a_over_re=50.0),
+    Case(
+        "baes-prior-edge-broad",
+        "baes",
+        100.0,
+        beta_0=-9.0,
+        beta_inf=0.98,
+        r_a_over_re=1.0,
+        eta=4.0,
+    ),
+    Case(
+        "baes-rapid-radializing",
+        "baes",
+        5.0,
+        beta_0=-9.0,
+        beta_inf=0.98,
+        r_a_over_re=0.005,
+        eta=10.0,
+    ),
+    Case(
+        "baes-outer-tangential",
+        "baes",
+        5.0,
+        beta_0=0.0,
+        beta_inf=-9.0,
+        r_a_over_re=50.0,
+        eta=0.1,
+    ),
+    Case(
+        "baes-fiducial-broad",
+        "baes",
+        100.0,
+        beta_0=-0.5,
+        beta_inf=0.65,
+        r_a_over_re=1.36,
+        eta=2.0,
+    ),
+)
+
+
+def _full_cases() -> list[Case]:
+    out: list[Case] = []
+    rs_ratios = (0.05, 5.0, 100.0)
+    for rs_ratio in rs_ratios:
+        for beta in (-9.0, -5.0, -1.0, 0.0, 0.5, 0.98):
+            out.append(
+                Case(
+                    f"constant-rs{rs_ratio:g}-beta{beta:g}",
+                    "constant",
+                    rs_ratio,
+                    beta_ani=beta,
+                )
+            )
+        for ra_ratio in (0.005, 0.05, 1.0, 50.0):
+            out.append(
+                Case(
+                    f"om-rs{rs_ratio:g}-ra{ra_ratio:g}",
+                    "om",
+                    rs_ratio,
+                    r_a_over_re=ra_ratio,
+                )
+            )
+
+    beta_pairs = (
+        ("radial-max", -9.0, 0.98),
+        ("radial-strong", -5.0, 0.98),
+        ("radial-moderate", -1.0, 0.98),
+        ("radial-inneriso", 0.0, 0.98),
+        ("tangential-max", 0.0, -9.0),
+        ("tangential-strong", -1.0, -9.0),
+    )
+    for rs_ratio in rs_ratios:
+        for label, beta_0, beta_inf in beta_pairs:
+            for eta in (0.1, 1.0, 4.0, 10.0):
+                for ra_ratio in (0.005, 1.0, 50.0):
+                    out.append(
+                        Case(
+                            f"baes-{label}-rs{rs_ratio:g}-eta{eta:g}-ra{ra_ratio:g}",
+                            "baes",
+                            rs_ratio,
+                            beta_0=beta_0,
+                            beta_inf=beta_inf,
+                            r_a_over_re=ra_ratio,
+                            eta=eta,
+                        )
+                    )
+    return out
+
+
+def _max_rel(candidate, reference) -> float:
+    import numpy as np
+
+    candidate = np.asarray(candidate, dtype=np.float64)
+    reference = np.asarray(reference, dtype=np.float64)
+    if not (np.isfinite(candidate).all() and np.isfinite(reference).all()):
+        return float("inf")
+    global_scale = max(float(np.max(np.abs(reference))), ABSOLUTE_FLOOR)
+    floor = max(global_scale * RELATIVE_FLOOR_FRACTION, ABSOLUTE_FLOOR)
+    denom = np.maximum(np.abs(reference), floor)
+    return float(np.max(np.abs(candidate - reference) / denom))
+
+
+def _make_model(case: Case):
+    from jeanspy.model_numpyro import (
+        BaesAnisotropyModel,
+        ConstantAnisotropyModel,
+        DSphModel,
+        NFWModel,
+        OsipkovMerrittModel,
+        PlummerModel,
+    )
+
+    if case.anisotropy == "constant":
+        ani = ConstantAnisotropyModel()
+    elif case.anisotropy == "om":
+        ani = OsipkovMerrittModel()
+    elif case.anisotropy == "baes":
+        ani = BaesAnisotropyModel()
+    else:  # pragma: no cover - Case values are defined in this file.
+        raise ValueError(case.anisotropy)
+
+    return DSphModel(
+        submodels={
+            "StellarModel": PlummerModel(),
+            "DMModel": NFWModel(),
+            "AnisotropyModel": ani,
+        }
+    )
+
+
+def _params(case: Case, dtype, *, re_pc: float):
+    import jax.numpy as jnp
+
+    raw = {
+        "re_pc": re_pc,
+        "rs_pc": case.rs_over_re * re_pc,
+        "rhos_Msunpc3": 7.5e-3,
+        "r_t_pc": case.r_t_over_re * re_pc,
+        "vmem_kms": 0.0,
+    }
+    if case.anisotropy == "constant":
+        raw["beta_ani"] = case.beta_ani
+    elif case.anisotropy == "om":
+        raw["r_a"] = case.r_a_over_re * re_pc
+    else:
+        raw.update(
+            {
+                "beta_0": case.beta_0,
+                "beta_inf": case.beta_inf,
+                "r_a": case.r_a_over_re * re_pc,
+                "eta": case.eta,
+            }
+        )
+    return {key: jnp.asarray(value, dtype=dtype) for key, value in raw.items()}
+
+
+def _n_kernel_for(profile: Profile, case: Case) -> int | None:
+    if case.anisotropy == "constant":
+        return profile.constant_n_kernel
+    if case.anisotropy == "baes":
+        return profile.baes_n_kernel
+    return None
+
+
+def _evaluate_candidate(dsph, R, params, case: Case, profile: Profile):
+    kwargs = {
+        "backend": "kernel",
+        "dm_mass_method": "analytic",
+        "jit": True,
+    }
+    n_kernel = _n_kernel_for(profile, case)
+    if n_kernel is not None:
+        kwargs["n_kernel"] = n_kernel
+
+    if profile.public_cpu_defaults:
+        # Deliberately omit n_u/u_max: the CI gate is tied to the public CPU
+        # defaults rather than merely reproducing a hard-coded benchmark grid.
+        return dsph.sigmalos2(R, params=params, **kwargs)
+
+    return dsph.sigmalos2(
+        R,
+        params=params,
+        n_u=profile.n_u,
+        u_max=profile.u_max,
+        **kwargs,
+    )
+
+
+def _evaluate_reference(dsph, R64, params64, case: Case):
+    kwargs = {
+        "backend": "kernel",
+        "n_u": REFERENCE_N_U,
+        "u_max": REFERENCE_U_MAX,
+        "dm_mass_method": "analytic",
+        "jit": True,
+    }
+    if case.anisotropy in {"constant", "baes"}:
+        kwargs["n_kernel"] = REFERENCE_N_KERNEL
+    return dsph.sigmalos2(R64, params=params64, **kwargs)
+
+
+def _time_hot(jax, func, repeats: int = 3) -> float:
+    jax.block_until_ready(func())
+    samples = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        jax.block_until_ready(func())
+        samples.append(time.perf_counter() - start)
+    return float(statistics.median(samples))
+
+
+def _check_cpu_defaults() -> None:
+    from jeanspy.model_numpyro import get_runtime_config
+
+    config = get_runtime_config()
+    if config["jax_backend_active"] != "cpu":
+        raise RuntimeError("This benchmark is intended to run on the CPU reference host")
+    if config["sigmalos2_n_u_default"] != CPU_N_U:
+        raise AssertionError(
+            "CPU sigmalos2 n_u default changed: "
+            f"expected {CPU_N_U}, got {config['sigmalos2_n_u_default']}"
+        )
+    if config["sigmalos2_u_max_default"] != DEFAULT_U_MAX:
+        raise AssertionError(
+            "CPU sigmalos2 u_max default changed: "
+            f"expected {DEFAULT_U_MAX:g}, got {config['sigmalos2_u_max_default']:g}"
+        )
+
+
+def run(cases: Iterable[Case], *, enforce: bool) -> None:
+    import numpy as np
+    import jax
+    import jax.numpy as jnp
+
+    if not bool(jax.config.read("jax_enable_x64")):
+        raise RuntimeError("The benchmark requires JAX_ENABLE_X64=true for references")
+
+    _check_cpu_defaults()
+    cases = tuple(cases)
+    re_pc = 220.0
+    R_over_re = np.geomspace(0.005, 10.0, 28)
+    R64 = jnp.asarray(R_over_re * re_pc, dtype=jnp.float64)
+
+    references = {}
+    models = {}
+    for case in cases:
+        dsph = _make_model(case)
+        models[case.name] = dsph
+        params64 = _params(case, jnp.float64, re_pc=re_pc)
+        references[case.name] = jax.block_until_ready(
+            _evaluate_reference(dsph, R64, params64, case)
+        )
+
+    print("sigmalos2 kernel numerical-accuracy contract")
+    print(f"target: max relative error <= {ACCURACY_TARGET:.1e}")
+    print(
+        "metric floor: max(|reference|, "
+        f"{RELATIVE_FLOOR_FRACTION:.0e} * max|reference|, {ABSOLUTE_FLOOR:.0e})"
+    )
+    print(
+        "reference: CPU float64 kernel, "
+        f"n_u={REFERENCE_N_U}, n_kernel={REFERENCE_N_KERNEL}, u_max={REFERENCE_U_MAX:g}"
+    )
+    print(f"cases={len(cases)}, R/Re=[0.005,10]")
+
+    failures = []
+    for profile in PROFILES:
+        dtype = jnp.float64 if profile.dtype_name == "float64" else jnp.float32
+        R = jnp.asarray(R_over_re * re_pc, dtype=dtype)
+        errors = []
+        runtimes = []
+        for case in cases:
+            dsph = models[case.name]
+            params = _params(case, dtype, re_pc=re_pc)
+
+            def candidate():
+                return _evaluate_candidate(dsph, R, params, case, profile)
+
+            value = jax.block_until_ready(candidate())
+            error = _max_rel(value, references[case.name])
+            errors.append((error, case.name))
+            runtimes.append(_time_hot(jax, candidate))
+
+        worst_error, worst_case = max(errors, key=lambda item: item[0])
+        print(
+            f"{profile.name:29s} worst_rel={worst_error:.3e} "
+            f"median_hot_ms={1e3 * statistics.median(runtimes):.3f} "
+            f"worst_case={worst_case}"
+        )
+        if worst_error > ACCURACY_TARGET:
+            failures.append((profile.name, worst_error, worst_case))
+
+    if enforce and failures:
+        details = "; ".join(
+            f"{name}: {error:.3e} ({case})" for name, error, case in failures
+        )
+        raise SystemExit(
+            f"sigmalos2 accuracy contract failed ({ACCURACY_TARGET:.1e}): {details}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark the documented sigmalos2 kernel accuracy contract."
+    )
+    parser.add_argument(
+        "--full",
+        action="store_true",
+        help="Run the full supported-domain stress matrix instead of the compact CI set.",
+    )
+    parser.add_argument(
+        "--no-enforce",
+        action="store_true",
+        help="Report errors without exiting non-zero when the target is exceeded.",
+    )
+    args = parser.parse_args()
+    run(_full_cases() if args.full else CI_CASES, enforce=not args.no_enforce)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jeanspy/model_numpyro.py
+++ b/src/jeanspy/model_numpyro.py
@@ -49,7 +49,7 @@ def _default_constant_kernel_n_quad() -> int:
 
 
 def _default_sigmalos2_n_u() -> int:
-    return 1024 if _prefers_gpu_x32() else 256
+    return 1024 if _prefers_gpu_x32() else 128
 
 
 def _default_sigmalos2_n_r() -> int:
@@ -57,7 +57,7 @@ def _default_sigmalos2_n_r() -> int:
 
 
 def _default_sigmalos2_u_max() -> float:
-    return 5000.0 if _prefers_gpu_x32() else 2e3
+    return 1.0e4
 
 
 def _normalize_constant_kernel_backend(backend: str) -> str:
@@ -1235,6 +1235,11 @@ class DSphModel(Model):
         ``kernel_outer_transform='sqrtlog'`` uses ``log(u)=x^2``.  Since
         ``K(u) ~ sqrt(u-1)`` at the lower endpoint, the transformed integrand
         is smooth in ``x``.  ``'log'`` retains the legacy uniform-log(u) grid.
+
+        The default ``sqrtlog`` grid is tuned to a maximum relative-error target
+        of ``1e-3`` on the documented Plummer+NFW dSph stress benchmark.  For
+        more extended or otherwise tail-sensitive models, increase ``u_max``
+        before increasing ``n_u``; then double ``n_u`` to verify convergence.
         """
         resolved_n_u = _default_sigmalos2_n_u() if n_u is None else int(n_u)
         resolved_u_max = _default_sigmalos2_u_max() if u_max is None else float(u_max)
@@ -1404,6 +1409,12 @@ class DSphModel(Model):
         must be one of ``"auto"``, ``"analytic"``, or ``"numeric"``. The
         default ``"auto"`` follows the DM model's autodiff-safe choice:
         analytic for NFW and numeric for Zhao.
+
+        For the kernel backend, the documented ``1e-3`` accuracy target applies
+        to the sampled Plummer+NFW stress envelope described in the README.
+        Outside that envelope, test convergence by increasing ``u_max`` first
+        and then doubling ``n_u``.  The Abel backend has a separate radial-grid
+        convergence control, ``n_r``.
         """
         backend_key = str(backend).strip().lower()
         ani = self.submodels["AnisotropyModel"]  # type: ignore[index]


### PR DESCRIPTION
## Summary

- define a maintained `1e-3` maximum-relative-error target for the JAX/NumPyro `sigmalos2` kernel backend over a documented dSph-oriented stress envelope
- retune the outer integration defaults from CPU `n_u=256, u_max=2000` to `n_u=128, u_max=10000`; keep the GPU float32 `n_u=1024` grid and raise its tail cutoff to `u_max=10000`
- add a deterministic CPU float64/float32 and GPU-oriented float32 numerical benchmark with a compact CI gate plus a full prior-edge sweep mode
- document the supported numerical envelope and a practical convergence procedure (`u_max` first, then `n_u`; `n_r` separately for Abel)

## Accuracy contract

The CI regression compares the public CPU defaults and a GPU-oriented float32 numerical proxy against a high-resolution float64 kernel reference (`n_u=1024`, `n_kernel=256`, `u_max=1e5`). The maintained threshold is `max relative error <= 1e-3`, with a small denominator floor for numerically negligible reference values.

The sampled envelope includes `0.005 <= R/Re <= 10`, NFW `0.05 <= rs/Re <= 100`, constant anisotropy through `beta=0.98` and down to `-9`, Osipkov-Merritt `0.005 <= r_a/Re <= 50`, and Baes-van Hese prior-edge cases with `0.1 <= eta <= 10`.

GitHub-hosted CI has no GPU, so the GPU-oriented float32 profile is an arithmetic/accuracy proxy rather than a GPU runtime measurement.

Closes #37