### PR TITLE
Guard package sources against SyntaxWarning regressions

### DIFF
--- a/tests/test_source_syntax.py
+++ b/tests/test_source_syntax.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import warnings
+
+
+def test_package_sources_compile_without_syntax_warnings():
+    src_root = Path(__file__).parents[1] / "src" / "jeanspy"
+    python_files = sorted(src_root.rglob("*.py"))
+    assert python_files
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SyntaxWarning)
+        for path in python_files:
+            source = path.read_text(encoding="utf-8")
+            compile(source, str(path), "exec")


### PR DESCRIPTION
## Summary

- rebase this follow-up onto the current `main`, after the classical backend refactor moved the old `_model_impl.py` implementation into focused modules
- verify that the refactored source already preserves LaTeX backslashes safely (the original invalid-escape warnings are no longer present)
- add a regression test that compiles every `src/jeanspy/**/*.py` file with `SyntaxWarning` promoted to an error, preventing invalid escape sequences from returning

The earlier direct `_model_impl.py` docstring edits were intentionally dropped because that file is now only a compatibility shim on `main`.

This remains separate from the numerical `sigmalos2` changes merged in #44.