### PR TITLE
Run final v0.1.0 release artifact preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Publish release to PyPI
+# Preflight trigger only: package and runtime inputs are unchanged from main.
 
 on:
   pull_request:


### PR DESCRIPTION
This PR exists only to trigger the release validation workflow against the current v0.1.0 packaging/runtime tree.

The branch starts from current `main` (`18b7ad3465d5702d10c18eb6ba95f636622009c1`) and changes only a comment in `.github/workflows/release.yml`; no package source, metadata, README, release validator, or runtime/package-data input is changed.

Do not merge this PR. Close it after `Build and validate distributions` succeeds.