### PR TITLE
Preserve NumPyro background write failures when polling status

### DIFF
--- a/src/jeanspy/sampler_numpyro.py
+++ b/src/jeanspy/sampler_numpyro.py
@@ -409,9 +409,16 @@ class NumPyroSampler:
         ]
         return sorted(chunk_paths, key=self._parse_chunk_index)
 
+    def _prune_successful_writes_locked(self) -> None:
+        self._write_futures = [
+            future for future in self._write_futures
+            if not future.done() or future.cancelled() or future.exception() is not None
+        ]
+
     def pending_write_count(self) -> int:
-        """Count unfinished writes without consuming their results or errors."""
+        """Count unfinished writes, retaining failures for flush/close."""
         with self._futures_lock:
+            self._prune_successful_writes_locked()
             return sum(not future.done() for future in self._write_futures)
 
     def flush(self) -> None:
@@ -546,6 +553,7 @@ class NumPyroSampler:
 
         future = self._executor.submit(self._write_chunk_store, chunk_index, prepared_tree)
         with self._futures_lock:
+            self._prune_successful_writes_locked()
             self._write_futures.append(future)
         return chunk_index, chunk_path, True
 

--- a/src/jeanspy/sampler_numpyro.py
+++ b/src/jeanspy/sampler_numpyro.py
@@ -410,22 +410,31 @@ class NumPyroSampler:
         return sorted(chunk_paths, key=self._parse_chunk_index)
 
     def pending_write_count(self) -> int:
+        """Count unfinished writes without consuming their results or errors."""
         with self._futures_lock:
-            self._write_futures = [future for future in self._write_futures if not future.done()]
-            return len(self._write_futures)
+            return sum(not future.done() for future in self._write_futures)
 
     def flush(self) -> None:
         with self._futures_lock:
             futures = list(self._write_futures)
             self._write_futures.clear()
+        error = None
         for future in futures:
-            future.result()
+            try:
+                future.result()
+            except Exception as exc:
+                if error is None:
+                    error = exc
+        if error is not None:
+            raise error
 
     def close(self) -> None:
-        self.flush()
-        if self._executor is not None:
-            self._executor.shutdown(wait=True)
-            self._executor = None
+        try:
+            self.flush()
+        finally:
+            if self._executor is not None:
+                self._executor.shutdown(wait=True)
+                self._executor = None
 
     def clear_resume_state(self) -> None:
         self.mcmc.post_warmup_state = None

--- a/tests/test_sampler_numpyro.py
+++ b/tests/test_sampler_numpyro.py
@@ -158,8 +158,10 @@ def test_polling_write_count_preserves_background_failure(tmp_path, monkeypatch,
             sampler._write_futures[0].result(timeout=10)
         assert sampler.pending_write_count() == 0
         assert sampler.pending_write_count() == 0
-        with pytest.raises(OSError, match="simulated disk write failure"):
+        with pytest.raises(OSError, match="simulated disk write failure") as caught:
             getattr(sampler, finish)()
+        import traceback
+        assert "fail_write" in [frame.name for frame in traceback.extract_tb(caught.value.__traceback__)]
         if finish == "close":
             assert sampler._executor is None
     finally:
@@ -186,3 +188,33 @@ def test_flush_waits_for_remaining_writes_after_failure(tmp_path):
         with pytest.raises(OSError, match="first write failed"):
             sampler.flush()
         assert successful.observed
+
+
+def test_status_prunes_successes_but_retains_cancellation_and_failure(tmp_path):
+    from concurrent.futures import Future, CancelledError
+
+    success, cancelled, failed, pending = (Future() for _ in range(4))
+    success.set_result(None)
+    cancelled.cancel()
+    failed.set_exception(OSError("failed write"))
+    sampler = NumPyroSampler(object(), output_dir=tmp_path)
+    try:
+        sampler._write_futures.extend([success, cancelled, failed, pending])
+        assert sampler.pending_write_count() == 1
+        assert sampler._write_futures == [cancelled, failed, pending]
+        pending.set_result(None)
+        assert sampler.pending_write_count() == 0
+        assert sampler._write_futures == [cancelled, failed]
+        with pytest.raises(CancelledError):
+            sampler.flush()
+    finally:
+        sampler.close()
+
+
+def test_submitting_writes_prunes_successes_without_status_polling(tmp_path, monkeypatch):
+    with NumPyroSampler(object(), output_dir=tmp_path) as sampler:
+        monkeypatch.setattr(sampler, "_write_chunk_store", lambda *args: None)
+        for _ in range(20):
+            sampler.save_samples_chunk(datatree=xr.DataTree())
+            sampler._write_futures[-1].result(timeout=10)
+            assert len(sampler._write_futures) == 1

--- a/tests/test_sampler_numpyro.py
+++ b/tests/test_sampler_numpyro.py
@@ -142,3 +142,47 @@ def test_numpyro_sampler_checkpoint_resume_and_chunk_loading(tmp_path, storage_b
     assert resumed_result.resumed is True
     first.close()
     resumed.close()
+
+@pytest.mark.parametrize("finish", ["flush", "close"])
+def test_polling_write_count_preserves_background_failure(tmp_path, monkeypatch, finish):
+    sampler = NumPyroSampler(object(), output_dir=tmp_path)
+
+    def fail_write(*args):
+        raise OSError("simulated disk write failure")
+
+    monkeypatch.setattr(sampler, "_write_chunk_store", fail_write)
+    try:
+        sampler.save_samples_chunk(datatree=xr.DataTree())
+        # Wait deterministically until the background write has failed.
+        with pytest.raises(OSError, match="simulated disk write failure"):
+            sampler._write_futures[0].result(timeout=10)
+        assert sampler.pending_write_count() == 0
+        assert sampler.pending_write_count() == 0
+        with pytest.raises(OSError, match="simulated disk write failure"):
+            getattr(sampler, finish)()
+        if finish == "close":
+            assert sampler._executor is None
+    finally:
+        sampler.close()
+
+
+def test_flush_waits_for_remaining_writes_after_failure(tmp_path):
+    from concurrent.futures import Future
+
+    failed = Future()
+    failed.set_exception(OSError("first write failed"))
+
+    class ObservedFuture(Future):
+        observed = False
+
+        def result(self, timeout=None):
+            self.observed = True
+            return super().result(timeout=timeout)
+
+    successful = ObservedFuture()
+    successful.set_result(None)
+    with NumPyroSampler(object(), output_dir=tmp_path) as sampler:
+        sampler._write_futures.extend([failed, successful])
+        with pytest.raises(OSError, match="first write failed"):
+            sampler.flush()
+        assert successful.observed


### PR DESCRIPTION
## Problem
Polling `pending_write_count()` removed completed failed futures, allowing a later `flush()` or `close()` to succeed after a disk write had failed.

## Changes
- Count unfinished writes without consuming results/errors.
- Drain every queued future before propagating the first write error.
- Shut down the executor even if flushing raises.
- Add deterministic regression tests for a real executor write failure, repeated status polling, flush/close propagation, and draining remaining futures.

## Validation
`python -m pytest tests/test_sampler_numpyro.py -q`: **8 passed**, including checkpoint/resume for zarr, h5netcdf and netcdf4.

Found in the final release review of `c5c94c1`. No existing issue/PR specifically covered this failure path.