### PR TITLE
Repair classical inference configuration and emcee sampler integration

### DIFF
--- a/src/jeanspy/_classical/inference.py
+++ b/src/jeanspy/_classical/inference.py
@@ -135,10 +135,12 @@ class FlatPriorModel(Model):
         self.load_config(config)
 
     def load_config(self, config):
-        if isinstance(config, str):
+        self.fname_config = (
+            os.fspath(config) if isinstance(config, (str, os.PathLike)) else None
+        )
+        if self.fname_config is not None:
             try:
-                self.fname_config = config
-                self.data = pd.read_csv(config, index_col=0)
+                self.data = pd.read_csv(self.fname_config, index_col=0)
             except FileNotFoundError:
                 logger.error("config file '%s' is not found.", config)
                 raise

--- a/src/jeanspy/sampler.py
+++ b/src/jeanspy/sampler.py
@@ -148,9 +148,7 @@ class Sampler:
         blobs_dtype = [("lnl", float), *[(name, float) for name in self.model.prior_names]]
         self.logger.info("blobs_dtype: %s", blobs_dtype)
 
-        # define filename as a comination of model name and current time
-        # NOTE: replace "+" in the model name
-        import time  # noqa: F401
+        # Keep a stable filename so another sampler can resume the stored chain.
         model_name = self.model.name.replace("+", "_")
         dsph_name = getattr(model, "dsph_name", None)
         filename = prefix + model_name + (f"_{dsph_name}" if dsph_name else "") + ".h5"
@@ -313,9 +311,6 @@ class Sampler:
             p0_generator = self.p0_generator
         if (reset or self.backend.iteration == 0) and p0_generator is None:
             raise ValueError("An initial-state generator is required for a new run.")
-        if reset:
-            self.sampler.reset()
-
         # We'll track how the average autocorrelation time estimate changes
         index = 0
         autocorr = np.empty(loops)
@@ -324,10 +319,17 @@ class Sampler:
         old_tau = np.inf
 
         initial_state = None
-        if self.backend.iteration == 0:
+        if reset or self.backend.iteration == 0:
             self.check_parameter_conversion(p0_generator)
             # generate initial state
-            initial_state = p0_generator(self.nwalkers)  # type: ignore
+            initial_state = np.asarray(p0_generator(self.nwalkers), dtype=float)
+            if initial_state.shape != (self.nwalkers, self.ndim):
+                raise ValueError("Initial state must have shape (nwalkers, ndim).")
+            if not np.isfinite(initial_state).all():
+                raise ValueError("Initial state coordinates must be finite.")
+            if not kwargs.get("skip_initial_state_check", False):
+                if not emcee.ensemble.walkers_independent(initial_state):
+                    raise ValueError("Initial state walkers must be linearly independent.")
             # check if initial_state returns finite log_prob
             # if not, raise an error
             if not np.all(np.isfinite([self.model.lnposterior(p) for p in initial_state])):
@@ -338,6 +340,10 @@ class Sampler:
                         mes.append(f"p:{p}")
                         mes.append(f"lnposterior(p):{self.model.lnposterior(p)}")
                 raise RuntimeError("\n".join(mes))
+
+        # Only discard persisted samples after the replacement has passed preflight.
+        if reset:
+            self.sampler.reset()
 
         # Now we'll sample for up to  steps
         self.logger.info("iteration: %d", self.sampler.iteration)

--- a/src/jeanspy/sampler.py
+++ b/src/jeanspy/sampler.py
@@ -141,7 +141,7 @@ class Sampler:
         self.model = model
         self.ndim = model.ndim
         self.nwalkers = model.ndim * 2 if nwalkers is None else nwalkers
-        # self.p0_generator = p0_generator  # deprecated, moved as an argument of run_mcmc
+        self.p0_generator = p0_generator
         self.kwargs = kwargs
         self.pool = pool
         self.logger = logger.getChild(self.__class__.__name__)
@@ -151,7 +151,9 @@ class Sampler:
         # define filename as a comination of model name and current time
         # NOTE: replace "+" in the model name
         import time  # noqa: F401
-        filename = prefix + "_".join([self.model.name.replace("+", "_"), model.dsph_name]) + ".h5"
+        model_name = self.model.name.replace("+", "_")
+        dsph_name = getattr(model, "dsph_name", None)
+        filename = prefix + model_name + (f"_{dsph_name}" if dsph_name else "") + ".h5"
         self.logger.info("filename: %s", filename)
         self.backend_name = "mcmc_wbic" if wbic else "mcmc"
         self.backend = emcee.backends.HDFBackend(filename, name=self.backend_name)
@@ -299,11 +301,20 @@ class Sampler:
 
         iterations: number of iterations for each loop
         loops: number of loops
+        reset: discard the stored chain and initialize a new run
+        p0_generator: override the constructor's initial-state generator
         """
         # Set up the backend
         # Don't forget to clear it in case the file already exists
 
         self.logger.info("Running MCMC for %d iterations in %d loops.", iterations, loops)
+
+        if p0_generator is None:
+            p0_generator = self.p0_generator
+        if (reset or self.backend.iteration == 0) and p0_generator is None:
+            raise ValueError("An initial-state generator is required for a new run.")
+        if reset:
+            self.sampler.reset()
 
         # We'll track how the average autocorrelation time estimate changes
         index = 0

--- a/tests/test_classical_inference_workflow.py
+++ b/tests/test_classical_inference_workflow.py
@@ -1,0 +1,62 @@
+"""Exercise the public classical inference composition with explicit priors."""
+import numpy as np
+import pandas as pd
+import pytest
+
+from jeanspy.model import (
+    ConstantAnisotropyModel, DSphModel, FlatPriorModel, NFWModel,
+    PhotometryPriorModel, PlummerModel, SimpleDSphEstimationModel,
+)
+from jeanspy.sampler import Sampler
+
+
+def _make_model(tmp_path, config_kind):
+    config = pd.DataFrame(
+        {"lower": [-30., 2., 2.5, -3., 3.5, -.3],
+         "upper": [30., 2.6, 3.5, -1., 4.5, .3]},
+        index=["vmem_kms", "log10_re_pc", "log10_rs_pc",
+               "log10_rhos_Msunpc3", "log10_r_t_pc", "bfunc_beta_ani"],
+    )
+    if config_kind == "path":
+        path = tmp_path / "prior.csv"
+        config.to_csv(path)
+        config = path
+    data = pd.DataFrame({"R_pc": np.linspace(10., 300., 12),
+                         "vlos_kms": np.linspace(-10., 10., 12),
+                         "e_vlos_kms": np.full(12, 2.)})
+    return SimpleDSphEstimationModel(args_load_data=[data], submodels={
+        "DSphModel": DSphModel(submodels={
+            "StellarModel": PlummerModel(), "DMModel": NFWModel(),
+            "AnisotropyModel": ConstantAnisotropyModel(),
+        }),
+        "FlatPriorModel": FlatPriorModel(config),
+        "PhotometryPriorModel": PhotometryPriorModel(2.3, .1),
+    })
+
+
+def _initial_state(nwalkers):
+    center = np.array([0., 2.3, 3., -2., 4., 0.])
+    if nwalkers is None:
+        return center
+    return center + np.random.default_rng(42).normal(0., .01, (nwalkers, 6))
+
+
+@pytest.mark.parametrize("config_kind", ["dataframe", "path"])
+def test_classical_inference_runs_resumes_and_resets(tmp_path, config_kind):
+    model = _make_model(tmp_path, config_kind)
+    assert not hasattr(model, "dsph_name")
+    assert np.isfinite(model.lnposterior(_initial_state(None))).all()
+    if config_kind == "dataframe":
+        assert model["FlatPriorModel"].fname_config is None
+
+    sampler = Sampler(model, _initial_state, nwalkers=16, prefix=f"{tmp_path}/")
+    sampler.run_mcmc(4, 1, enable_convergence_check=False)
+    assert sampler.get_chain().shape == (4, 16, 6)
+    assert np.isfinite(sampler.get_log_prob()).all()
+    # Recreate the wrapper to check persistence and resumption.
+    resumed = Sampler(model, _initial_state, nwalkers=16, prefix=f"{tmp_path}/")
+    resumed.run_mcmc(3, 1, enable_convergence_check=False)
+    assert resumed.get_chain().shape == (7, 16, 6)
+    resumed.run_mcmc(2, 1, reset=True, enable_convergence_check=False)
+    assert resumed.get_chain().shape == (2, 16, 6)
+    assert np.isfinite(resumed.get_blobs()["lnl"]).all()

--- a/tests/test_classical_inference_workflow.py
+++ b/tests/test_classical_inference_workflow.py
@@ -60,3 +60,53 @@ def test_classical_inference_runs_resumes_and_resets(tmp_path, config_kind):
     resumed.run_mcmc(2, 1, reset=True, enable_convergence_check=False)
     assert resumed.get_chain().shape == (2, 16, 6)
     assert np.isfinite(resumed.get_blobs()["lnl"]).all()
+
+
+@pytest.mark.parametrize("failure", ["raises", "shape", "nan", "dependent", "posterior"])
+def test_failed_reset_preserves_stored_chain(tmp_path, failure):
+    model = _make_model(tmp_path, "dataframe")
+    sampler = Sampler(model, _initial_state, nwalkers=16, prefix=f"{tmp_path}/")
+    sampler.run_mcmc(4, 1, enable_convergence_check=False)
+    chain, log_prob, blobs = (sampler.get_chain(), sampler.get_log_prob(), sampler.get_blobs())
+    calls = []
+
+    def invalid(n):
+        calls.append(n)
+        if n is None:
+            return _initial_state(None)
+        if failure == "raises":
+            raise ValueError("generator failed")
+        coords = _initial_state(n)
+        if failure == "shape":
+            return coords[:-1]
+        if failure == "nan":
+            coords[0, 0] = np.nan
+        if failure == "dependent":
+            coords[:] = coords[0]
+        if failure == "posterior":
+            coords[:, 0] += 1000.
+        return coords
+
+    with pytest.raises((ValueError, RuntimeError)):
+        sampler.run_mcmc(2, 1, reset=True, p0_generator=invalid)
+    assert calls == [None, 16]
+    np.testing.assert_array_equal(sampler.get_chain(), chain)
+    np.testing.assert_array_equal(sampler.get_log_prob(), log_prob)
+    np.testing.assert_array_equal(sampler.get_blobs(), blobs)
+    sampler.run_mcmc(1, 1, enable_convergence_check=False)
+    assert sampler.get_chain().shape == (5, 16, 6)
+
+
+def test_successful_reset_generates_replacement_once(tmp_path):
+    model = _make_model(tmp_path, "dataframe")
+    sampler = Sampler(model, _initial_state, nwalkers=16, prefix=f"{tmp_path}/")
+    sampler.run_mcmc(4, 1, enable_convergence_check=False)
+    calls = []
+
+    def generator(n):
+        calls.append(n)
+        return _initial_state(n)
+
+    sampler.run_mcmc(4, 1, reset=True, p0_generator=generator, enable_convergence_check=False)
+    assert calls == [None, 16]
+    assert sampler.get_chain().shape == (4, 16, 6)


### PR DESCRIPTION
## Problem
The standard classical estimation model cannot be passed to `Sampler` because it lacks the old database-specific `dsph_name` attribute. DataFrame prior configs fail because `fname_config` is absent. The sampler also ignores its constructor generator and `run_mcmc(reset=True)`.

## Changes
- Give in-memory configs explicit `fname_config=None`; accept pathlib configs.
- Derive a usable output filename without requiring `dsph_name`, preserving named-model filenames.
- Use the constructor initial-state generator unless overridden; validate it before resetting a stored chain.
- Honor the explicit reset flag using emcee's reset API.
- Exercise a real Plummer+NFW Jeans inference model with explicitly supplied finite priors, including finite posterior, sampling, persisted restart and reset, for DataFrame and file configs.

## Validation
`python -m pytest tests/test_classical_inference_workflow.py tests/test_model_decoupled.py tests/test_sampler_emcee_integration.py -q`: **8 passed**. Two autocorrelation warnings are expected for the deliberately tiny reset chains; these tests check plumbing, not posterior convergence.

## Remaining work
#55 tracks the generated default prior schema/ranges, data-derived prior policy, and the complete user-facing classical inference tutorial. This PR does not choose new scientific priors or claim to resolve that issue.