### PR TITLE
Update shared kinematic data in place and reject unsafe resizing

### DIFF
--- a/src/jeanspy/_classical/inference.py
+++ b/src/jeanspy/_classical/inference.py
@@ -292,8 +292,13 @@ class SimpleDSphEstimationModel(FittableModel, Model):
 
     def load_data(self, data, shared=False):
         """Load explicitly supplied observed kinematic data."""
+        previous_shared = getattr(self, "shared", False)
         self.shared = shared
-        self.reset_data(data.astype(self.dtype))
+        try:
+            self.reset_data(data)
+        except Exception:
+            self.shared = previous_shared
+            raise
 
     def reset_data(self, data):
         """Replace observations while sampler workers are idle.
@@ -357,50 +362,61 @@ class SimpleDSphEstimationModel(FittableModel, Model):
 
     @data.setter
     def data(self, data: pd.DataFrame):
+        fields = ("R_pc", "vlos_kms", "e_vlos_kms")
+        shape = data["R_pc"].shape
         if self.shared and hasattr(self, "shared_shape"):
-            if data["R_pc"].shape != self.shared_shape:
+            if shape != self.shared_shape:
                 raise ValueError(
                     "Cannot resize shared kinematic data; construct a new model "
                     "for a different number of observations."
                 )
         data = data.astype(self.dtype)
-        self._n_data = len(data)
+        values = {field: data[field].values for field in fields}
+        if any(array.shape != shape for array in values.values()):
+            raise ValueError("Kinematic columns must have matching shapes.")
         if not self.shared:
-            self._data = DotDict(
-                {
-                    "R_pc": data["R_pc"].values,
-                    "vlos_kms": data["vlos_kms"].values,
-                    "e_vlos_kms": data["e_vlos_kms"].values,
-                }
-            )
+            self._data = DotDict(values)
+            self._n_data = len(data)
             return
 
-        self.shared_shape = data["R_pc"].shape
-        assert self.shared_shape == data["vlos_kms"].shape
-        assert self.shared_shape == data["e_vlos_kms"].shape
-        self.buffer_size = data["R_pc"].values.nbytes
-        assert self.buffer_size == data["vlos_kms"].values.nbytes
-        assert self.buffer_size == data["e_vlos_kms"].values.nbytes
-
-        for field in ("R_pc", "vlos_kms", "e_vlos_kms"):
-            shm_name = self.shared_memory_basename + "_" + field
-            shm = getattr(self, f"shm_{field}", None)
-            if shm is None:
-                try:
-                    shm = SharedMemory(
-                        name=shm_name,
-                        create=True,
-                        size=self.buffer_size,
+        buffer_size = values["R_pc"].nbytes
+        handles = {}
+        arrays = {}
+        opened = []
+        created = []
+        try:
+            # Validate every segment before changing any observations or metadata.
+            for field in fields:
+                shm_name = self.shared_memory_basename + "_" + field
+                shm = getattr(self, f"shm_{field}", None)
+                if shm is None:
+                    try:
+                        shm = SharedMemory(name=shm_name, create=True, size=buffer_size)
+                        created.append(shm)
+                    except FileExistsError:
+                        shm = SharedMemory(name=shm_name, create=False)
+                    opened.append(shm)
+                if shm.size != buffer_size:
+                    raise ValueError(
+                        f"Shared memory {shm.name!r} has size {shm.size} bytes; "
+                        f"expected {buffer_size} bytes for {field}."
                     )
-                except FileExistsError:
-                    shm = SharedMemory(name=shm_name, create=False)
-            array = np.ndarray(
-                self.shared_shape,
-                dtype=self.dtype,
-                buffer=shm.buf,
-            )
-            array[:] = data[field].values
-            setattr(self, f"shm_{field}", shm)
+                handles[field] = shm
+                arrays[field] = np.ndarray(shape, dtype=self.dtype, buffer=shm.buf)
+        except Exception:
+            arrays.clear()
+            for shm in opened:
+                shm.close()
+            for shm in created:
+                shm.unlink()
+            raise
+
+        for field in fields:
+            arrays[field][:] = values[field]
+            setattr(self, f"shm_{field}", handles[field])
+        self._n_data = len(data)
+        self.shared_shape = shape
+        self.buffer_size = buffer_size
 
     def _release_shared_memory(self, suffix):
         if not self.shared:

--- a/src/jeanspy/_classical/inference.py
+++ b/src/jeanspy/_classical/inference.py
@@ -296,6 +296,11 @@ class SimpleDSphEstimationModel(FittableModel, Model):
         self.reset_data(data.astype(self.dtype))
 
     def reset_data(self, data):
+        """Replace observations while sampler workers are idle.
+
+        Shared models keep their buffer shape so existing readers stay attached.
+        Construct a new model to use a different number of observations.
+        """
         self.data = data
         lower = self.data["vlos_kms"].min()
         upper = self.data["vlos_kms"].max()
@@ -352,6 +357,13 @@ class SimpleDSphEstimationModel(FittableModel, Model):
 
     @data.setter
     def data(self, data: pd.DataFrame):
+        if self.shared and hasattr(self, "shared_shape"):
+            if data["R_pc"].shape != self.shared_shape:
+                raise ValueError(
+                    "Cannot resize shared kinematic data; construct a new model "
+                    "for a different number of observations."
+                )
+        data = data.astype(self.dtype)
         self._n_data = len(data)
         if not self.shared:
             self._data = DotDict(
@@ -372,20 +384,22 @@ class SimpleDSphEstimationModel(FittableModel, Model):
 
         for field in ("R_pc", "vlos_kms", "e_vlos_kms"):
             shm_name = self.shared_memory_basename + "_" + field
-            try:
-                shm = SharedMemory(
-                    name=shm_name,
-                    create=True,
-                    size=self.buffer_size,
-                )
-                array = np.ndarray(
-                    self.shared_shape,
-                    dtype=self.dtype,
-                    buffer=shm.buf,
-                )
-                array[:] = data[field].values
-            except FileExistsError:
-                shm = SharedMemory(name=shm_name, create=False)
+            shm = getattr(self, f"shm_{field}", None)
+            if shm is None:
+                try:
+                    shm = SharedMemory(
+                        name=shm_name,
+                        create=True,
+                        size=self.buffer_size,
+                    )
+                except FileExistsError:
+                    shm = SharedMemory(name=shm_name, create=False)
+            array = np.ndarray(
+                self.shared_shape,
+                dtype=self.dtype,
+                buffer=shm.buf,
+            )
+            array[:] = data[field].values
             setattr(self, f"shm_{field}", shm)
 
     def _release_shared_memory(self, suffix):

--- a/tests/test_shared_data_reset.py
+++ b/tests/test_shared_data_reset.py
@@ -59,3 +59,66 @@ def test_shared_resize_is_rejected_without_mutating_model(shared_model, n):
     for field, values in original.items():
         np.testing.assert_array_equal(model.data[field], values)
     pd.testing.assert_frame_equal(model["FlatPriorModel"].data, old_bounds)
+
+
+@pytest.mark.parametrize("size", [8, 20])
+def test_existing_handle_size_mismatch_preserves_other_buffers(shared_model, size):
+    model = shared_model
+    original = {field: values.copy() for field, values in model.data.items()}
+    old_bounds = model["FlatPriorModel"].data.copy()
+    original_handle = model.shm_e_vlos_kms
+    wrong = SharedMemory(create=True, size=size)
+    model.shm_e_vlos_kms = wrong
+    try:
+        new = pd.DataFrame({field: values + 100. for field, values in original.items()})
+        with pytest.raises(ValueError, match="expected 12 bytes for e_vlos_kms"):
+            model.reset_data(new)
+        assert model.n_data == 3
+        assert model.shared_shape == (3,)
+        assert model.buffer_size == 12
+        # In particular the earlier fields must not have been copied yet.
+        model.shm_e_vlos_kms = original_handle
+        for field, values in original.items():
+            np.testing.assert_array_equal(model.data[field], values)
+        pd.testing.assert_frame_equal(model["FlatPriorModel"].data, old_bounds)
+    finally:
+        model.shm_e_vlos_kms = original_handle
+        wrong.close()
+        wrong.unlink()
+
+
+@pytest.mark.parametrize("size", [8, 20])
+def test_stale_attachment_failure_cleans_new_segments_and_restores_state(tmp_path, size):
+    data = pd.DataFrame(dict(R_pc=[10., 20., 30.], vlos_kms=[-1., 0., 1.],
+                             e_vlos_kms=[1., 2., 3.]))
+    model = get_default_estimation_model(data, 2.3, .1, config=str(tmp_path / "prior.csv"))
+    basename = f"SimpleDSphEstimationModel_{id(model)}"
+    stale = SharedMemory(name=basename + "_e_vlos_kms", create=True, size=size)
+    old_bounds = model["FlatPriorModel"].data.copy()
+    try:
+        with pytest.raises(ValueError, match="expected 12 bytes for e_vlos_kms"):
+            model.load_data(data + 100., shared=True)
+        assert model.shared is False
+        assert model.n_data == 3
+        assert not hasattr(model, "shared_shape")
+        assert not hasattr(model, "buffer_size")
+        for field in data:
+            np.testing.assert_array_equal(model.data[field], data[field].values)
+            assert not hasattr(model, f"shm_{field}")
+        pd.testing.assert_frame_equal(model["FlatPriorModel"].data, old_bounds)
+        # New segments from this failed attempt are gone; the stale segment
+        # belongs to somebody else and must remain available.
+        for field in ("R_pc", "vlos_kms"):
+            with pytest.raises(FileNotFoundError):
+                SharedMemory(name=basename + "_" + field)
+        attached = SharedMemory(name=stale.name)
+        attached.close()
+    finally:
+        stale.close()
+        stale.unlink()
+    # A clean retry must succeed after the stale segment is removed.
+    model.load_data(data + 100., shared=True)
+    try:
+        np.testing.assert_array_equal(model.data.vlos_kms, [99., 100., 101.])
+    finally:
+        model.release_shared_memory()

--- a/tests/test_shared_data_reset.py
+++ b/tests/test_shared_data_reset.py
@@ -1,0 +1,61 @@
+"""Shared observation updates must reach existing readers without stale buffers."""
+from multiprocessing.shared_memory import SharedMemory
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from jeanspy.model import get_default_estimation_model
+
+
+@pytest.fixture
+def shared_model(tmp_path):
+    data = pd.DataFrame(dict(R_pc=[10., 20., 30.], vlos_kms=[-1., 0., 1.],
+                             e_vlos_kms=[1., 2., 3.]))
+    model = get_default_estimation_model(data, 2.3, .1, config=str(tmp_path / "prior.csv"))
+    model.load_data(data, shared=True)
+    try:
+        yield model
+    finally:
+        model.release_shared_memory()
+
+
+def test_reset_updates_existing_shared_readers(shared_model):
+    model = shared_model
+    fields = ("R_pc", "vlos_kms", "e_vlos_kms")
+    handles = {field: getattr(model, f"shm_{field}") for field in fields}
+    readers = {field: SharedMemory(name=handle.name) for field, handle in handles.items()}
+    replacement = pd.DataFrame(dict(R_pc=[40., 50., 60.], vlos_kms=[99., 100., 101.],
+                                    e_vlos_kms=[4., 5., 6.]))
+    try:
+        # Repeat to catch reopening/leaking handles and stale reattachment paths.
+        for offset in (0., 10.):
+            new = replacement + offset  # float64 input; shared layout remains float32
+            model.reset_data(new)
+            assert model.n_data == 3
+            for field in fields:
+                assert getattr(model, f"shm_{field}") is handles[field]
+                observed = np.ndarray((3,), dtype=model.dtype, buffer=readers[field].buf)
+                np.testing.assert_array_equal(observed, new[field].to_numpy(dtype=model.dtype))
+                np.testing.assert_array_equal(model.data[field], observed)
+            bounds = model["FlatPriorModel"].data.loc["vmem_kms"]
+            assert bounds["lower"] == new.vlos_kms.min()
+            assert bounds["upper"] == new.vlos_kms.max()
+    finally:
+        for reader in readers.values():
+            reader.close()
+
+
+@pytest.mark.parametrize("n", [2, 4])
+def test_shared_resize_is_rejected_without_mutating_model(shared_model, n):
+    model = shared_model
+    original = {field: values.copy() for field, values in model.data.items()}
+    old_bounds = model["FlatPriorModel"].data.copy()
+    new = pd.DataFrame({field: np.arange(n, dtype=float) for field in original})
+    with pytest.raises(ValueError, match="Cannot resize shared kinematic data"):
+        model.reset_data(new)
+    assert model.n_data == 3
+    assert model.shared_shape == (3,)
+    for field, values in original.items():
+        np.testing.assert_array_equal(model.data[field], values)
+    pd.testing.assert_frame_equal(model["FlatPriorModel"].data, old_bounds)


### PR DESCRIPTION
## Problem
`reset_data()` reattached to existing shared memory without copying new observations. A same-size replacement silently left old radii, velocities and errors in the likelihood. Changing the row count could also mismatch the allocated buffer and the model's shape.

## Changes
- Reuse existing shared-memory handles and copy every replacement column into the existing buffers.
- Normalize incoming data to the declared dtype before writing the buffer.
- Reject shared row-count changes before mutating observations, shape, count or prior bounds; users must construct a new model for a different sample size.
- Document that callers must stop active readers/sampler workers during updates.
- Test two consecutive updates against independently attached shared-memory readers and verify no handle replacement.
- Test both larger and smaller replacements are rejected without changing existing state.

## Validation
`python -m pytest tests/test_shared_data_reset.py tests/test_model_decoupled.py -q`: **8 passed**.
Also combined with #58 and #59 locally: **19 targeted tests passed**; the three branches merge without conflicts.

## Scope
This fixes observation storage, not the data-derived prior policy/cached prior bounds tracked in #55. Buffers are not resized underneath existing worker processes.