### PR TITLE
Fix Zhao mass domain and steep-cusp quadrature accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,27 @@ numeric mass, and request `method="analytic"` or
 `dm_mass_method="analytic"` explicitly only when the closed form is desired
 without those Zhao shape-parameter gradients.
 
+Zhao mass supports `a > 0`, `g < 3`, finite `b` (including `b <= 3`),
+positive finite scale radius/density, and positive truncation radius. The
+requested radius must be nonnegative and finite after truncation. Its numerical
+integral removes the central cusp with a power substitution and integrates the
+outer profile in log radius, without a central cutoff. Both classical mass
+spellings and JAX `auto`/`numeric` mass accept `n_steps=128` (Gauss nodes per
+segment); JAX Jeans methods expose this as `dm_mass_n_steps`. Increase this
+independently of `n_u`/`n_r` to check mass and LOS convergence separately.
+The explicit JAX analytic path falls back to this integral at `b <= 3` or
+saturated beta arguments; the exact NFW limit still uses its stable closed form.
+
+Regression tests compare independent SciPy integration on a grid spanning
+`a=0.5..5`, `b=2..8`, `g=0..2.99`, and truncated `r/rs=1e-6..1e6`:
+relative tolerances are `1e-6` in float64 and `5e-5` in float32 for default
+numerical mass. These are tested grid bounds, not an accuracy guarantee for
+all Zhao parameters or for the outer Jeans integral. Check convergence outside
+that grid, especially closer to `g=3`. Classical invalid mass inputs raise
+`ValueError`; JAX returns NaN under eager execution and JIT. Jeans solvers
+preserve invalid mass signals, and the NumPyro likelihood rejects invalid
+velocity variances with negative infinite log probability.
+
 ## Example Notebooks
 
 The recommended starting point is:

--- a/src/jeanspy/_classical/profiles.py
+++ b/src/jeanspy/_classical/profiles.py
@@ -6,9 +6,10 @@ from abc import abstractmethod
 
 import numpy as np
 from scipy.integrate import quad
-from scipy.special import beta, betainc, hyp2f1, k0
+from scipy.special import hyp2f1, k0
 
 from ..dequad import dequad
+from .._zhao import enclosed_mass as _zhao_mass, valid_domain as _zhao_valid
 from .core import Model
 from .jfactor import C_J, _ullio2016_inner_weight, _ullio2016_weight
 
@@ -369,40 +370,21 @@ class ZhaoModel(DMModel):
             1.0 + np.power(x, a), -(b - g) / a
         )
 
-    def enclosure_mass(self, r_pc):
-        rs_pc = self.params.rs_pc
-        rhos = self.params.rhos_Msunpc3
-        a, b, g = self.params.a, self.params.b, self.params.g
-        r_t_pc = self.params.r_t_pc
+    def enclosed_mass(self, r_pc, *, n_steps=128):
+        """Finite-radius Zhao mass for a > 0 and g < 3, including b <= 3.
 
-        r_pc_trunc = np.minimum(np.asarray(r_pc), r_t_pc)
-
-        if (
-            np.isclose(a, 1.0, atol=1e-7, rtol=0.0)
-            and np.isclose(b, 3.0, atol=1e-7, rtol=0.0)
-            and np.isclose(g, 1.0, atol=1e-7, rtol=0.0)
-        ):
-            x_nfw = r_pc_trunc / rs_pc
-            return (
-                4.0
-                * np.pi
-                * rs_pc**3
-                * rhos
-                * (np.log1p(x_nfw) - x_nfw / (1.0 + x_nfw))
+        n_steps controls Gauss-Legendre nodes per regularized segment.
+        """
+        params = {k: getattr(self.params, k) for k in self.required_param_names}
+        if not np.all(_zhao_valid(np.asarray(r_pc), params, np)):
+            raise ValueError(
+                "Invalid Zhao mass domain: require positive scales, a > 0, "
+                "g < 3, finite slopes and nonnegative truncated radii"
             )
+        return _zhao_mass(r_pc, params, xp=np, n_steps=n_steps)
 
-        x = np.power(r_pc_trunc / rs_pc, a)
-        argbeta0 = (3.0 - g) / a
-        argbeta1 = (b - 3.0) / a
-        return (
-            4.0
-            * np.pi
-            * rs_pc**3
-            * rhos
-            / a
-            * beta(argbeta0, argbeta1)
-            * betainc(argbeta0, argbeta1, x / (1.0 + x))
-        )
+    def enclosure_mass(self, r_pc, *, n_steps=128):
+        return self.enclosed_mass(r_pc, n_steps=n_steps)
 
 
 class NFWModel(DMModel):

--- a/src/jeanspy/_classical/solver.py
+++ b/src/jeanspy/_classical/solver.py
@@ -73,6 +73,9 @@ class DSphModel(Model):
         enclosed_mass = self["DMModel"].enclosed_mass
         kernel = self["AnisotropyModel"].kernel
         r = R_pc * u
+        mass = enclosed_mass(r)
+        if not np.all(np.isfinite(mass) & (mass >= 0)):
+            raise ValueError("Dark-matter enclosed mass must be finite and nonnegative")
 
         return (
             2.0
@@ -81,7 +84,7 @@ class DSphModel(Model):
             * density_3d(r)
             / density_2d(R_pc)
             * GMsun_m3s2
-            * enclosed_mass(r)
+            * mass
             / parsec
             * 1e-6
         )

--- a/src/jeanspy/_zhao.py
+++ b/src/jeanspy/_zhao.py
@@ -1,0 +1,60 @@
+"""Cusp-regularized Zhao mass quadrature, shared by NumPy and JAX."""
+
+from functools import lru_cache
+import operator
+
+import numpy as np
+
+PARAM_NAMES = ("rs_pc", "rhos_Msunpc3", "a", "b", "g", "r_t_pc")
+
+
+@lru_cache(maxsize=16)
+def quadrature(n_steps):
+    n = operator.index(n_steps)
+    if n < 8:
+        raise ValueError("n_steps must be an integer >= 8")
+    nodes, weights = np.polynomial.legendre.leggauss(n)
+    return (nodes + 1) / 2, weights / 2
+
+
+def valid_domain(r, params, xp):
+    rs, rho, a, b, g, rt = (xp.asarray(params[k]) for k in PARAM_NAMES)
+    return (
+        xp.isfinite(rs) & (rs > 0) & xp.isfinite(rho) & (rho > 0)
+        & xp.isfinite(a) & (a > 0) & xp.isfinite(b)
+        & xp.isfinite(g) & (g < 3) & (rt > 0) & ~xp.isnan(rt)
+        & (r >= 0) & ~xp.isnan(r) & xp.isfinite(xp.minimum(r, rt))
+    )
+
+
+def enclosed_mass(r_pc, params, *, xp, n_steps=128):
+    """Integrate separately below rs (power coordinate) and above rs (log).
+
+    With p=3-g and y=x*u**(4/p), the inner density-volume integrand
+    becomes proportional to u**3, even as g approaches 3 from below.
+    No central cutoff is required. n_steps is the Gauss order per segment.
+    Invalid dynamic inputs return NaN, including under JIT.
+    """
+    r = xp.asarray(r_pc)
+    dtype = xp.result_type(r, xp.asarray(params["rs_pc"]), 1.0)
+    u, w = (xp.asarray(v, dtype=dtype) for v in quadrature(operator.index(n_steps)))
+    rs, rho, a, b, g, rt = (
+        xp.asarray(params[k], dtype=dtype) for k in PARAM_NAMES
+    )
+    valid = valid_domain(r, params, xp)
+    # Safe placeholders keep inactive branches finite at zero/invalid inputs.
+    rs = xp.where(rs > 0, rs, 1.0)
+    a = xp.where(a > 0, a, 1.0)
+    p = xp.where(g < 3, 3 - g, 1.0)
+    x = xp.where(valid & (r > 0), xp.minimum(r, rt) / rs, 1.0)
+    log_c = xp.log(xp.minimum(x, 1.0))[..., None]
+    log_u = xp.log(u)
+    q = (b - g) / a
+    inner_shape = xp.exp(-q * xp.logaddexp(0.0, a * (log_c + 4 / p * log_u)))
+    inner = (4 / p) * xp.exp(p * log_c[..., 0]) * xp.sum(w * u**3 * inner_shape, axis=-1)
+    length = xp.log(xp.maximum(x, 1.0))
+    t = length[..., None] * u
+    outer_shape = xp.exp(p * t - q * xp.logaddexp(0.0, a * t))
+    outer = length * xp.sum(w * outer_shape, axis=-1)
+    mass = 4 * xp.pi * rho * rs**3 * (inner + outer)
+    return xp.where(valid, xp.where(r == 0, 0.0, mass), xp.nan)

--- a/src/jeanspy/model_numpyro.py
+++ b/src/jeanspy/model_numpyro.py
@@ -16,6 +16,7 @@ import os
 import warnings
 
 from ._jax_env import configure_jax_environment
+from ._zhao import enclosed_mass as _zhao_mass, valid_domain as _zhao_valid
 
 configure_jax_environment()
 
@@ -749,7 +750,8 @@ class DMModel(Model):
         )
 
     def enclosed_mass(
-        self, r_pc: jnp.ndarray, method: str = "auto", *, params: Mapping[str, Any]
+        self, r_pc: jnp.ndarray, method: str = "auto", *, params: Mapping[str, Any],
+        n_steps: Optional[int] = None,
     ) -> jnp.ndarray:
         """Return enclosed mass with selectable backend.
 
@@ -757,6 +759,9 @@ class DMModel(Model):
         analytic for NFW and numeric for Zhao. Pass ``method="analytic"`` to
         request a closed form explicitly, or ``method="numeric"`` for the
         autodiff-friendly numerical integral.
+
+        ``n_steps`` sets numerical mass resolution (Zhao: Gauss nodes per
+        segment). None uses the model default; analytic methods ignore it.
         """
         method_key = str(method).strip().lower()
         if method_key == "auto":
@@ -779,17 +784,19 @@ class DMModel(Model):
                     f"{self.__class__.__name__} does not have an analytic enclosed_mass implementation"
                 )
         elif resolved_method == "numeric":
-            return self.enclosed_mass_numeric(r_pc, params=params)
+            numeric_kwargs = {} if n_steps is None else {"n_steps": n_steps}
+            return self.enclosed_mass_numeric(r_pc, params=params, **numeric_kwargs)
         else:
             raise ValueError(
                 f"method must be 'analytic', 'numeric', or 'auto', got {method!r}"
             )
 
     def enclosure_mass(
-        self, r_pc: jnp.ndarray, method: str = "auto", *, params: Mapping[str, Any]
+        self, r_pc: jnp.ndarray, method: str = "auto", *, params: Mapping[str, Any],
+        n_steps: Optional[int] = None,
     ) -> jnp.ndarray:
         """Compatibility spelling shared with the classical backend."""
-        return self.enclosed_mass(r_pc, method=method, params=params)
+        return self.enclosed_mass(r_pc, method=method, params=params, n_steps=n_steps)
 
 
 class NFWModel(DMModel):
@@ -848,10 +855,18 @@ class ZhaoModel(DMModel):
         x = r / rs
         return rhos * x ** (-g_arr) * (1.0 + x**a_arr) ** (-(b_arr - g_arr) / a_arr)
 
+    def enclosed_mass_numeric(self, r_pc, *, params, n_steps=128):
+        """Cusp-regularized, differentiable quadrature without a central cutoff."""
+        return _zhao_mass(r_pc, params, xp=jnp, n_steps=n_steps)
+
     def enclosed_mass_betainc(
         self, r_pc: jnp.ndarray, *, params: Mapping[str, Any]
     ) -> jnp.ndarray:
         """Enclosed mass from the Zhao incomplete-beta closed form.
+
+        For b <= 3 (outside the beta domain), or a saturated beta argument,
+        use the regularized numerical integral. Shape autodiff is unsupported
+        on this explicit analytic path; use auto/numeric for inference.
 
         The NFW-limit branch ``(a,b,g)=(1,3,1)`` is handled analytically because
         the raw beta/betainc expression becomes indeterminate there even though
@@ -879,7 +894,7 @@ class ZhaoModel(DMModel):
             & (jnp.abs(g_arr - 1.0) <= tol)
         )
         argbeta1_safe = jnp.where(
-            is_nfw_limit, jnp.asarray(1.0, dtype=argbeta1.dtype), argbeta1
+            argbeta1 <= 0, jnp.asarray(1.0, dtype=argbeta1.dtype), argbeta1
         )
         coeff_general = 4.0 * jnp.pi * rs**3 * rhos / a_arr
         mass_general = (
@@ -891,7 +906,15 @@ class ZhaoModel(DMModel):
         coeff_nfw = 4.0 * jnp.pi * rhos * rs**3
         mass_nfw = coeff_nfw * _nfw_enclosed_mass_shape(x_raw)
 
-        return jnp.where(is_nfw_limit, mass_nfw, mass_general)
+        # The incomplete-beta domain excludes b <= 3; finite-radius mass does not.
+        fallback = self.enclosed_mass_numeric(r_pc, params=params)
+        general = jnp.where(
+            (argbeta1 > 0) & (z > 0) & (z < 1) & jnp.isfinite(mass_general),
+            mass_general,
+            fallback,
+        )
+        mass = jnp.where(is_nfw_limit, mass_nfw, general)
+        return jnp.where(_zhao_valid(jnp.asarray(r_pc), params, jnp), mass, jnp.nan)
 
     def enclosed_mass_analytic(
         self, r_pc: jnp.ndarray, *, params: Mapping[str, Any]
@@ -1224,6 +1247,7 @@ class DSphModel(Model):
         u_min_eps: float = 1e-6,
         kernel_outer_transform: str = DEFAULT_SIGMALOS2_KERNEL_OUTER_TRANSFORM,
         dm_mass_method: str = "auto",
+        dm_mass_n_steps: Optional[int] = None,
     ) -> jnp.ndarray:
         r"""Kernel-based sigma_los^2(R) implementation.
 
@@ -1279,7 +1303,8 @@ class DSphModel(Model):
         re_pc = params["re_pc"]
         nu3 = stellar.density_3d(r, re_pc=re_pc)
         sig2 = stellar.density_2d(R2d, re_pc=re_pc)
-        M = dm.enclosed_mass(r, method=dm_mass_method, params=params)
+        mass_kwargs = {} if dm_mass_n_steps is None else {"n_steps": dm_mass_n_steps}
+        M = dm.enclosed_mass(r, method=dm_mass_method, params=params, **mass_kwargs)
 
         kernel_kwargs: Dict[str, Any] = {}
         if isinstance(ani, ConstantAnisotropyModel):
@@ -1309,7 +1334,11 @@ class DSphModel(Model):
         # Numerical safety: sigma_los^2 should be >=0, but coarse quadrature / edge params
         # can produce tiny negatives or NaNs during MCMC initialization.
         out = jnp.nan_to_num(out, nan=0.0, neginf=0.0, posinf=1e12)
-        return jnp.clip(out, min=0.0, max=1e12)
+        return jnp.where(
+            jnp.all(jnp.isfinite(M) & (M >= 0), axis=-1),
+            jnp.clip(out, min=0.0, max=1e12),
+            jnp.nan,
+        )
 
     def sigmalos2_abel(
         self,
@@ -1320,6 +1349,7 @@ class DSphModel(Model):
         u_max: Optional[float] = None,
         r_min_factor: float = 0.5,
         dm_mass_method: str = "auto",
+        dm_mass_n_steps: Optional[int] = None,
     ) -> jnp.ndarray:
         r"""Compute sigma_los^2(R) via a 1D Jeans solve and two Abel transforms."""
         R = jnp.atleast_1d(jnp.asarray(R_pc))
@@ -1361,7 +1391,8 @@ class DSphModel(Model):
         nu3 = stellar.density_3d(r, re_pc=re_pc)
         beta = jnp.asarray(ani.beta(r, params=params), dtype=dtype)
         f_r = jnp.asarray(ani.f(r, params=params), dtype=dtype)
-        mass = dm.enclosed_mass(r, method=dm_mass_method, params=params)
+        mass_kwargs = {} if dm_mass_n_steps is None else {"n_steps": dm_mass_n_steps}
+        mass = dm.enclosed_mass(r, method=dm_mass_method, params=params, **mass_kwargs)
 
         grav = (GMsun_m3s2 * mass / PARSEC_M) * 1e-6
         rhs_log_r = f_r * nu3 * grav / r
@@ -1377,7 +1408,11 @@ class DSphModel(Model):
         numer = 2.0 * (abel_rj - (R**2) * abel_beta_j_over_r)
         out = numer / sigma
         out = jnp.nan_to_num(out, nan=0.0, neginf=0.0, posinf=1e12)
-        return jnp.clip(out, min=0.0, max=1e12)
+        return jnp.where(
+            jnp.all(jnp.isfinite(mass) & (mass >= 0)),
+            jnp.clip(out, min=0.0, max=1e12),
+            jnp.nan,
+        )
 
     def sigmalos2(
         self,
@@ -1395,6 +1430,7 @@ class DSphModel(Model):
         kernel_outer_transform: str = DEFAULT_SIGMALOS2_KERNEL_OUTER_TRANSFORM,
         r_min_factor: float = 0.5,
         dm_mass_method: str = "auto",
+        dm_mass_n_steps: Optional[int] = None,
     ) -> jnp.ndarray:
         """Compute sigma_los^2(R) via the requested backend.
 
@@ -1409,6 +1445,8 @@ class DSphModel(Model):
         must be one of ``"auto"``, ``"analytic"``, or ``"numeric"``. The
         default ``"auto"`` follows the DM model's autodiff-safe choice:
         analytic for NFW and numeric for Zhao.
+        ``dm_mass_n_steps`` sets the numerical mass resolution independently
+        of the outer Jeans grid. Analytic mass methods ignore this resolution.
 
         For the kernel backend, the documented ``1e-3`` accuracy target applies
         to the sampled Plummer+NFW stress envelope described in the README.
@@ -1463,6 +1501,7 @@ class DSphModel(Model):
                     u_max=resolved_u_max,
                     r_min_factor=r_min_factor,
                     dm_mass_method=dm_mass_method,
+                    dm_mass_n_steps=dm_mass_n_steps,
                 )
             return self.sigmalos2_kernel(
                 R_value,
@@ -1474,6 +1513,7 @@ class DSphModel(Model):
                 u_min_eps=u_min_eps,
                 kernel_outer_transform=kernel_outer_transform_key,
                 dm_mass_method=dm_mass_method,
+                dm_mass_n_steps=dm_mass_n_steps,
             )
 
         if not use_jit:
@@ -1490,6 +1530,7 @@ class DSphModel(Model):
             float(u_min_eps),
             float(r_min_factor),
             dm_mass_method,
+            dm_mass_n_steps,
             bool(jax.config.read("jax_enable_x64")),
             jax.default_backend(),
         )

--- a/src/jeanspy/sampler_numpyro.py
+++ b/src/jeanspy/sampler_numpyro.py
@@ -245,6 +245,10 @@ class JeansLikelihoodModel:
     def __call__(self, R_pc: Any, vlos_kms: Any, e_vlos_kms: Any) -> None:
         params = self.sample_parameters()
         sigma2 = self.dsph_model.sigmalos2(jnp.asarray(R_pc), params=params, **self.sigmalos2_kwargs)
+        valid_sigma2 = jnp.all(jnp.isfinite(sigma2) & (sigma2 >= 0))
+        numpyro.factor("valid_sigmalos2", jnp.where(valid_sigma2, 0.0, -jnp.inf))
+        # Reject invalid models, but keep the observation distribution well-defined.
+        sigma2 = jnp.where(jnp.isfinite(sigma2) & (sigma2 >= 0), sigma2, 1.0)
         sigma2 = jnp.clip(sigma2, min=self.sigma2_bounds[0], max=self.sigma2_bounds[1])
         scale = jnp.sqrt(sigma2 + jnp.asarray(e_vlos_kms) ** 2)
         loc = self._resolve_velocity_mean(params)

--- a/tests/test_zhao_mass_domain.py
+++ b/tests/test_zhao_mass_domain.py
@@ -1,0 +1,188 @@
+"""Zhao release regressions: independent mass references and inference safety."""
+from contextlib import contextmanager
+from itertools import product
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.integrate import quad
+from numpyro.infer.util import log_density
+
+from jeanspy import model as classical
+from jeanspy import model_numpyro as functional
+from jeanspy.sampler_numpyro import JeansLikelihoodModel
+
+
+@contextmanager
+def precision(enabled):
+    previous = jax.config.jax_enable_x64
+    jax.config.update("jax_enable_x64", enabled)
+    try:
+        yield
+    finally:
+        jax.config.update("jax_enable_x64", previous)
+
+
+def params(**overrides):
+    return dict(dict(rs_pc=1000., rhos_Msunpc3=.01, a=1., b=4., g=2.5,
+                     r_t_pc=10000.), **overrides)
+
+
+def reference_mass(x, a, b, g):
+    # QUADPACK's algebraically weighted adaptive rule treats the cusp directly;
+    # it does not use the implementation's power substitution or fixed nodes.
+    p, q = 3 - g, (b - g) / a
+    c = min(x, 1.)
+    inner = c**p * quad(lambda u: (1 + (c*u)**a)**(-q), 0, 1,
+                        weight="alg", wvar=(p-1, 0), epsabs=1e-10,
+                        epsrel=1e-10, limit=300)[0]
+    outer = quad(lambda t: np.exp(p*t-q*np.logaddexp(0, a*t)), 0,
+                 np.log(max(x, 1.)), epsabs=1e-10, epsrel=1e-10)[0]
+    return 4*np.pi*(inner+outer)
+
+
+@pytest.mark.parametrize("x64,rtol", [(True, 1e-6), (False, 5e-5)])
+def test_mass_accuracy_grid(x64, rtol):
+    with precision(x64):
+        radii = np.array([1e-6, .01, 1., 100., 1e6])
+        model = functional.ZhaoModel()
+        evaluate = jax.jit(lambda r, p: model.enclosed_mass(r, params=p))
+        for a, b, g in product([.5, 1., 3., 5.], [2., 3., 4., 8.], [0., 1., 2.5, 2.99]):
+            p = params(rs_pc=1., rhos_Msunpc3=1., r_t_pc=1e7, a=a, b=b, g=g)
+            expected = [reference_mass(x, a, b, g) for x in radii]
+            np.testing.assert_allclose(evaluate(jnp.asarray(radii), p), expected, rtol=rtol)
+            if x64:
+                np.testing.assert_allclose(classical.ZhaoModel(**p).enclosed_mass(radii),
+                                           expected, rtol=rtol)
+
+
+@pytest.mark.parametrize("g", [0., 1., 2.5, 2.9, 2.99])
+def test_dehnen_closed_form_and_truncation(g):
+    with precision(True):
+        p = params(g=g)
+        radii = np.array([0., 1e-3, 10., 1000., 10000., 20000.])
+        x = np.minimum(radii, p['r_t_pc']) / p['rs_pc']
+        expected = 4*np.pi*.01*1000**3/(3-g)*(x/(1+x))**(3-g)
+        for model in (classical.ZhaoModel(**p), functional.ZhaoModel()):
+            kw = {} if isinstance(model, classical.ZhaoModel) else {'params': p}
+            np.testing.assert_allclose(model.enclosed_mass(radii, **kw), expected, rtol=1e-8)
+            np.testing.assert_allclose(model.enclosure_mass(radii, **kw), expected, rtol=1e-8)
+            assert np.shape(model.enclosed_mass(1000., **kw)) == ()
+
+
+@pytest.mark.parametrize("b,g", [(2., 0.), (3., 0.), (3., 1.), (4., 2.5)])
+def test_explicit_analytic_domain_and_nfw_limit(b, g):
+    with precision(True):
+        p = params(b=b, g=g)
+        r = jnp.array([0., .001, 100., 1000., 1e5])
+        model = functional.ZhaoModel()
+        result = jax.jit(lambda r: model.enclosed_mass(r, params=p, method='analytic'))(r)
+        np.testing.assert_allclose(result, classical.ZhaoModel(**p).enclosed_mass(r), rtol=1e-7)
+        if b == 3 and g == 0:
+            assert float(result[2]) == pytest.approx(33785.62865245551, rel=1e-8)
+
+
+@pytest.mark.parametrize("x64,rtol", [(True, 3e-5), (False, .015)])
+def test_numeric_parameter_gradients_match_finite_differences(x64, rtol):
+    with precision(x64):
+        p = params(a=.8, b=3., g=2.9)
+        names = tuple(p)
+        values = jnp.array([p[k] for k in names])
+        def objective(v):
+            return jnp.sum(jnp.log(functional.ZhaoModel().enclosed_mass(
+                jnp.array([200., 3000., 30000.]), params=dict(zip(names, v)))))
+        actual = np.asarray(jax.jit(jax.grad(objective))(values))
+        # Independent float64 classical evaluation, with a tighter Gauss rule.
+        def reference(v):
+            return np.log(classical.ZhaoModel(**dict(zip(names, v))).enclosed_mass(
+                np.array([200., 3000., 30000.]), n_steps=256)).sum()
+        v = np.asarray(values, dtype=float)
+        expected = []
+        for i in range(len(names)):
+            delta = max(abs(v[i]), .01)*1e-5
+            offset = np.eye(len(names))[i]*delta
+            expected.append((reference(v+offset)-reference(v-offset))/(2*delta))
+        np.testing.assert_allclose(actual, expected, rtol=rtol, atol=1e-7)
+
+
+def dsph(module, p):
+    if module is classical:
+        return module.DSphModel(submodels=dict(
+            StellarModel=module.PlummerModel(re_pc=220.), DMModel=module.ZhaoModel(**p),
+            AnisotropyModel=module.ConstantAnisotropyModel(beta_ani=0.)))
+    return module.DSphModel(submodels=dict(
+        StellarModel=module.PlummerModel(), DMModel=module.ZhaoModel(),
+        AnisotropyModel=module.ConstantAnisotropyModel()))
+
+
+@pytest.mark.parametrize("bad", [dict(a=0.), dict(g=3.), dict(g=3.1), dict(b=np.nan),
+                                  dict(rs_pc=0.), dict(rhos_Msunpc3=-1.), dict(r_t_pc=-1.)])
+def test_invalid_domains_are_not_zero_mass(bad):
+    p = params(**bad)
+    with pytest.raises(ValueError, match='Zhao mass domain'):
+        classical.ZhaoModel(**p).enclosed_mass(100.)
+    for method in ('auto', 'analytic'):
+        evaluate = lambda r: functional.ZhaoModel().enclosed_mass(r, params=p, method=method)
+        assert np.isnan(evaluate(100.))
+        assert np.isnan(jax.jit(evaluate)(100.))
+
+
+@pytest.mark.parametrize("backend", ['kernel', 'abel'])
+def test_los_mass_resolution_and_invalid_likelihood(backend):
+    with precision(True):
+        p = dict(params(g=2.5), re_pc=220., beta_ani=0., vmem_kms=0.)
+        model = dsph(functional, p)
+        r = jnp.array([50., 100., 300.])
+        kwargs = dict(backend=backend, n_u=257, n_r=1024, u_max=2000.)
+        low = model.sigmalos2(r, params=p, dm_mass_n_steps=64, **kwargs)
+        high = model.sigmalos2(r, params=p, dm_mass_n_steps=128, **kwargs)
+        np.testing.assert_allclose(low, high, rtol=1e-5)
+        refined = model.sigmalos2(r, params=p, dm_mass_n_steps=128,
+                                  **dict(kwargs, n_u=513, n_r=2048))
+        np.testing.assert_allclose(high, refined, rtol=.004)
+        eager = model.sigmalos2(r, params=p, dm_mass_n_steps=128, jit=False, **kwargs)
+        np.testing.assert_allclose(high, eager, rtol=1e-10)
+        assert np.all(np.asarray(high) > 0)
+        invalid = dict(p, g=3.)
+        assert np.isnan(model.sigmalos2(r, params=invalid, **kwargs)).all()
+        likelihood = JeansLikelihoodModel(model, [], parameter_postprocess=lambda _: invalid,
+                                          sigmalos2_kwargs=kwargs)
+        value, _ = log_density(likelihood, (r, jnp.zeros(3), jnp.ones(3)), {}, {})
+        assert np.isneginf(value)
+
+
+def test_classical_los_beta_domain_and_bad_mass():
+    p = params(b=3., g=0.)
+    model = dsph(classical, p)
+    r = np.array([50., 100., 300.])
+    expected = model.sigmalos2(r)
+    assert np.all(expected > 0)
+    assert np.all(model.sigmar2(r) > 0)
+    with precision(True):
+        actual = dsph(functional, p).sigmalos2(
+            jnp.asarray(r), params=dict(p, re_pc=220., beta_ani=0.),
+            n_u=513, u_max=2000.)
+        np.testing.assert_allclose(actual, expected, rtol=1e-4)
+    model['DMModel'].enclosed_mass = lambda r: np.full_like(r, np.nan)
+    with pytest.raises(ValueError, match='enclosed mass'):
+        model.sigmalos2(r)
+
+
+def test_resolution_and_radius_validation():
+    p = params()
+    for value in [0, 7, 12.5]:
+        with pytest.raises((TypeError, ValueError)):
+            functional.ZhaoModel().enclosed_mass(100., params=p, n_steps=value)
+    for radius in [-1., np.nan]:
+        with pytest.raises(ValueError):
+            classical.ZhaoModel(**p).enclosed_mass(radius)
+        assert np.isnan(functional.ZhaoModel().enclosed_mass(radius, params=p))
+
+
+@pytest.mark.parametrize("x64", [True, False])
+def test_explicit_analytic_fallback_at_saturated_beta_argument(x64):
+    with precision(x64):
+        p = params(rs_pc=1., rhos_Msunpc3=1., r_t_pc=1e7, a=5., b=3.01, g=1.)
+        result = functional.ZhaoModel().enclosed_mass(jnp.array(1e6), params=p, method='analytic')
+        assert float(result) == pytest.approx(reference_mass(1e6, 5., 3.01, 1.), rel=5e-5)


### PR DESCRIPTION
## Problem

Zhao mass has two related release blockers: the incomplete-beta formula returns NaN for valid finite-radius profiles with b <= 3, and the default JAX uniform-grid integral overweights steep integrable cusps. Invalid mass could then be sanitized into a plausible zero LOS dispersion.

Closes #53
Closes #54

## Changes

- Share a NumPy/JAX Zhao mass integral that removes the central cusp using y = min(r/rs, 1) * u**(4/(3-g)), then integrates the region above rs in log radius. Use 128 Gauss-Legendre nodes per segment with no central cutoff.
- Use the regularized integral for classical Zhao mass and the autodiff-safe JAX auto/numeric paths. Preserve the explicit JAX incomplete-beta/NFW path, with numerical fallback outside the beta domain or when its argument saturates.
- Validate positive scales, a > 0, g < 3, finite slopes, and nonnegative radii finite after truncation. Classical evaluation raises ValueError; JAX propagates NaN consistently under JIT.
- Preserve invalid mass signals through both LOS backends and reject invalid velocity variances with negative infinite NumPyro log probability.
- Expose n_steps on mass methods and dm_mass_n_steps on JAX Jeans methods, including the JIT cache key. These control numerical mass independently of the outer Jeans grid; explicit analytic methods retain their default fallback resolution.
- Document the tested numerical grid, convergence controls, and existing explicit-analytic shape-autodiff limitation.

## Validation

- Full suite including opt-in MCMC: `.venv/bin/python -m pytest tests --run-mcmc -q` — 235 passed, 37 subtests.
- Final targeted regression run after adding saturated-beta and radial/LOS checks: `.venv/bin/python -m pytest tests/test_zhao_mass_domain.py tests/test_dm_mass_consistency.py tests/test_dm_mass_method_api.py -q` — 33 passed, 2 subtests.
- Independent adaptive SciPy mass references on a grid spanning a=0.5..5, b=2..8, g=0..2.99, r/rs=1e-6..1e6; tolerances 1e-6 (float64) and 5e-5 (float32).
- Analytic Dehnen masses (including g=2.99), scalar/vector/truncated radii, NFW and non-NFW b=3 cases, JIT, finite-difference checks of parameter gradients, mass-versus-outer-grid LOS convergence, and invalid likelihood rejection.
- Issue #53's mass(100 pc) now agrees with 33785.62865245551 Msun. Issue #54's g=2.5 mass agrees with the analytic 177715317.52633464 Msun instead of the previous ~132% overestimate.

Validation was on CPU. The numerical grid is a tested envelope, not a guarantee for arbitrary Zhao parameters or arbitrary tracer/anisotropy combinations. Classical Zhao now uses quadrature rather than the previous incomplete-beta expression. The separate projected-radius contract in #56 remains open.
